### PR TITLE
Set output_file via addOption instead of OpenIpoptOutputFile

### DIFF
--- a/src/ipopt.jl
+++ b/src/ipopt.jl
@@ -105,17 +105,8 @@ function optimize(solver::IPOPT, cache, x0, lx, ux, lg, ug, rows, cols)
     for (key, value) in options
         addOption(prob, key, value)
     end
-
-    # open output file
-    filename = "ipopt.out"
-    print_level = 5
-    if haskey(options, "output_file")
-        filename = options["output_file"]
-    end
-    if haskey(options, "print_level")
-        print_level = options["print_level"]
-    end
-    Ipopt.OpenIpoptOutputFile(prob, filename, print_level)
+    addOption(prob, "output_file", get(options, "output_file", "ipopt.out"))
+    addOption(prob, "print_level", get(options, "print_level", 5))
 
     # solve problem
     prob.x = x0


### PR DESCRIPTION
The file opened by OpenIpoptOutputFile is not released until FreeIpoptProblem is called. This is a problem with Julia's garbage collector, which is not guaranteed to run immediately. Thus, solving a model twice with the same log file can cause an error.

This was raised by https://discourse.julialang.org/t/ipopt-suppress-output-file-generation/127595
and also by https://github.com/jump-dev/Ipopt.jl/issues/470

(I have no idea who two people independently opened the same issue on the same day!)