### PR TITLE
Update ipopt.jl - To free ipopt.out file

### DIFF
--- a/src/ipopt.jl
+++ b/src/ipopt.jl
@@ -120,6 +120,14 @@ function optimize(solver::IPOPT, cache, x0, lx, ux, lg, ug, rows, cols)
     # solve problem
     prob.x = x0
     status = Ipopt.IpoptSolve(prob)
+    
+    # copy the values you need BEFORE freeing
+    result_x = copy(prob.x)
+    result_f = prob.obj_val
+    result_status = ApplicationReturnStatus[status]
+
+    # now it's safe to free the C-side memory
+    finalize(prob)
 
     return prob.x, prob.obj_val, ApplicationReturnStatus[status], nothing
 end


### PR DESCRIPTION
Hi, with this change it is possible to run multiple sequential times Ipopt  from SNOW.jl, without encountering the error: 
```julia
julia> rm("ipopt.out")
ERROR: IOError: unlink("ipopt.out"): resource busy or locked (EBUSY)
```
I have tested it and seem to work well.