### PR TITLE
SparseDiffTools.jl is depreciated & causing compat issues, replace with SparseMatrixColoring.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Andrew Ning <aning@byu.edu> and contributors"]
 version = "0.3.2"
 
 [deps]
-BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 DiffResults = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"
 DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
@@ -27,9 +26,8 @@ SparseMatrixColorings = "0.3, 0.4"
 julia = "1.10"
 
 [extras]
-BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Test", "BenchmarkTools", "Zygote"]
+test = ["Test", "Zygote"]

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-SparseDiffTools = "47a9eef4-7e08-11e9-0b38-333d64bd3804"
+SparseMatrixColorings = "0a514795-09f3-496d-8182-132a7b665d35"
 
 [compat]
 DiffResults = "1.0"
@@ -20,8 +20,8 @@ ForwardDiff = "0.10, 1"
 Ipopt = "1.0"
 Requires = "1.1"
 ReverseDiff = "1.9"
-SparseDiffTools = "1.13, 2"
-julia = "1.6"
+SparseMatrixColorings = "0.3, 0.4"
+julia = "1.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,9 @@ authors = ["Andrew Ning <aning@byu.edu> and contributors"]
 version = "0.3.2"
 
 [deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 DiffResults = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"
+DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
@@ -15,6 +17,7 @@ SparseMatrixColorings = "0a514795-09f3-496d-8182-132a7b665d35"
 
 [compat]
 DiffResults = "1.0"
+DifferentiationInterface = "0.7.20"
 FiniteDiff = "2.8"
 ForwardDiff = "0.10, 1"
 Ipopt = "1.0"
@@ -24,7 +27,9 @@ SparseMatrixColorings = "0.3, 0.4"
 julia = "1.10"
 
 [extras]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Test"]
+test = ["Test", "BenchmarkTools", "Zygote"]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Features:
 - Easy switching between various differentiation methods: ForwardDiff, ReverseDiff, Zygote, FiniteDiff (forward, central, complex step), and user-defined derivatives.
 - Derivative calculations are all non-allocating during optimization.
 - Outputs are also cached as applicable to avoid unnecessary function calls.
-- Methods are provided to help determine sparsity patterns, sparse Jacobians can be updated efficiently with SparseDiffTools (using graph coloring), and the sparsity structure is passed to the solvers.
+- Methods are provided to help determine sparsity patterns, sparse Jacobians can be updated efficiently with SparseMatrixColorings (using graph coloring), and the sparsity structure is passed to the solvers.
 
 To Install
 

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
+SNOW = "105f6ee8-0889-46b1-9d4b-65e03cbc8f13"

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,19 @@
+# Benchmarks
+
+Run the current benchmark suite with:
+
+```bash
+./benchmark/run.sh
+```
+
+To compare with an older checkout, provide its commit hash:
+
+```bash
+./benchmark/run.sh --old 66d0297 both
+```
+
+The benchmark definitions are in [`benchmarks.jl`](benchmarks.jl), and the
+benchmark environment is defined in [`Project.toml`](Project.toml).
+
+The runner prints the full timing summary for every derivative mode and
+coloring-algorithm permutation.

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,88 @@
+using BenchmarkTools
+using SNOW
+using SparseArrays
+
+const BENCH_NSAMPLES = parse(Int, get(ENV, "BENCH_NSAMPLES", "2000"))
+const BENCH_NEVALS = parse(Int, get(ENV, "BENCH_NEVALS", "1"))
+const BENCH_MODE = Symbol(lowercase(get(ENV, "BENCH_MODE", "both")))
+const BENCH_ALGORITHMS = let
+    names = split(get(ENV, "BENCH_ALGORITHMS", "greedy,greedy_smallest_last,greedy_largest_first,constant"), ',')
+    [Symbol(lowercase(name)) for name in names if !isempty(name)]
+end
+
+function test2!(g, x)
+    nx = length(x)
+    @inbounds for i in 1:nx
+        im1 = i == 1 ? 0.0 : x[i-1]
+        ip1 = i == nx ? 0.0 : x[i+1]
+        g[i] = x[i]^2 + 0.1 * im1 + 0.2 * ip1
+    end
+    return x[1]^2 - x[2]
+end
+
+function make_pattern(nx)
+    rows = Int[]
+    cols = Int[]
+    for i in 1:nx
+        push!(rows, i)
+        push!(cols, i)
+        if i > 1
+            push!(rows, i)
+            push!(cols, i - 1)
+        end
+        if i < nx
+            push!(rows, i)
+            push!(cols, i + 1)
+        end
+    end
+    return SNOW.SparsePattern(sparse(rows, cols, ones(Float64, length(rows)), nx, nx))
+end
+
+function coloring_algorithm(name::Symbol, nx)
+    smc = SNOW.SparseMatrixColorings
+    if name == :greedy
+        return smc.GreedyColoringAlgorithm()
+    elseif name == :greedy_smallest_last
+        return smc.GreedyColoringAlgorithm(smc.SmallestLast())
+    elseif name == :greedy_largest_first
+        return smc.GreedyColoringAlgorithm(smc.LargestFirst())
+    elseif name == :constant
+        return smc.ConstantColoringAlgorithm(ones(nx, nx), [mod1(i, 3) for i in 1:nx])
+    else
+        error("invalid benchmark coloring algorithm: $name")
+    end
+end
+
+function make_benchmark(dmode::Symbol, algorithm::Symbol)
+    nx = 300
+    ng = nx
+    x = 2.0 .* ones(nx)
+    g = zeros(ng)
+    df = zeros(nx)
+    sp = make_pattern(nx)
+    dg = zeros(length(sp.rows))
+    method = dmode == :fd ? [SNOW.ReverseAD(), SNOW.ForwardFD()] : [SNOW.ReverseAD(), SNOW.ForwardAD()]
+
+    cache = if algorithm == :legacy
+        SNOW.createcache(sp, method, test2!, nx, ng)
+    else
+        SNOW.createcache(sp, method, test2!, nx, ng;
+            coloring_algorithm=coloring_algorithm(algorithm, nx))
+    end
+
+    SNOW.evaluate!(g, df, dg, x, cache)
+    return @benchmarkable SNOW.evaluate!($g, $df, $dg, $x, $cache) samples=BENCH_NSAMPLES evals=BENCH_NEVALS
+end
+
+if BENCH_MODE ∉ (:ad, :fd, :both)
+    error("invalid BENCH_MODE=$(BENCH_MODE); expected ad, fd, or both")
+end
+
+const BENCH_MODES = BENCH_MODE == :both ? (:ad, :fd) : (BENCH_MODE,)
+const SUITE = BenchmarkGroup()
+for mode in BENCH_MODES
+    group = SUITE[String(mode)] = BenchmarkGroup()
+    for algorithm in BENCH_ALGORITHMS
+        group[String(algorithm)] = make_benchmark(mode, algorithm)
+    end
+end

--- a/benchmark/run.sh
+++ b/benchmark/run.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+JULIA_BIN="${JULIA_BIN:-julia}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+OLD_SNOW_DIR="${OLD_SNOW_DIR:-$REPO_DIR/../SNOW_old_color_bench}"
+OLD_COMMIT="${OLD_SNOW_COMMIT:-}"
+MODE="${MODE:-both}"
+
+usage() {
+    cat <<'USAGE'
+Usage:
+  ./benchmark/run.sh [--old COMMIT] [ad|fd|both]
+
+Without --old, benchmark the current checkout only.  --old adds an optional
+comparison against a checkout at the given git commit.
+
+Environment:
+  JULIA_BIN: Julia executable (default: julia)
+  OLD_SNOW_DIR: old checkout path (default: ../SNOW_old_color_bench)
+  OLD_SNOW_COMMIT: old commit; equivalent to --old COMMIT
+  BENCH_NSAMPLES: BenchmarkTools samples (default: 2000)
+  BENCH_NEVALS: evaluations per sample (default: 1)
+  BENCH_ALGORITHMS: comma-separated current algorithms
+
+Examples:
+  ./benchmark/run.sh
+  ./benchmark/run.sh --old 66d0297 both
+  OLD_SNOW_COMMIT=66d0297 ./benchmark/run.sh fd
+USAGE
+}
+
+if ! command -v "$JULIA_BIN" >/dev/null 2>&1; then
+    echo "Julia not found: set JULIA_BIN to a Julia executable path" >&2
+    exit 1
+fi
+
+while (($#)); do
+    case "$1" in
+        --old)
+            (($# >= 2)) || { echo "--old requires a commit" >&2; usage; exit 1; }
+            OLD_COMMIT="$2"
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        ad|fd|both)
+            MODE="$1"
+            shift
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+BENCH_NSAMPLES="${BENCH_NSAMPLES:-2000}"
+BENCH_NEVALS="${BENCH_NEVALS:-1}"
+BENCH_ALGORITHMS="${BENCH_ALGORITHMS:-greedy,greedy_smallest_last,greedy_largest_first,constant}"
+BENCH_TMP_ROOT="$(mktemp -d -t snow-color-bench-XXXXXX)"
+trap 'rm -rf "$BENCH_TMP_ROOT"' EXIT
+
+build_bench_env() {
+    local env_dir="$1"
+    local snow_dir="$2"
+
+    mkdir -p "$env_dir"
+    "$JULIA_BIN" --project="$env_dir" -e '
+        using Pkg
+        Pkg.activate(ARGS[1]; shared = false)
+        Pkg.develop(path = ARGS[2])
+        Pkg.add("BenchmarkTools")
+        Pkg.instantiate()
+        Pkg.precompile()
+    ' "$env_dir" "$snow_dir"
+}
+
+run_bench() {
+    local label="$1"
+    local env_dir="$2"
+    local algorithms="$3"
+
+    echo "----- $label -----"
+    BENCH_MODE="$MODE" BENCH_ALGORITHMS="$algorithms" \
+        BENCH_NSAMPLES="$BENCH_NSAMPLES" BENCH_NEVALS="$BENCH_NEVALS" \
+        "$JULIA_BIN" --project="$env_dir" -e \
+        'include(ARGS[1]); results = BenchmarkTools.run(SUITE; verbose = true); function print_results(group, pad = ""); for (id, result) in group; if result isa BenchmarkTools.BenchmarkGroup; println(pad, id, ":"); print_results(result, pad * "  "); else; print(pad, id, ": "); show(stdout, MIME"text/plain"(), result); println(); end; end; end; print_results(results)' \
+        "$SCRIPT_DIR/benchmarks.jl"
+}
+
+build_bench_env "$BENCH_TMP_ROOT/current" "$REPO_DIR"
+run_bench "SNOW current" "$BENCH_TMP_ROOT/current" "$BENCH_ALGORITHMS"
+
+if [ -n "$OLD_COMMIT" ]; then
+    expected_old_head="$(git -C "$REPO_DIR" rev-parse "$OLD_COMMIT^{commit}")"
+    if [ -e "$OLD_SNOW_DIR/.git" ]; then
+        old_head="$(git -C "$OLD_SNOW_DIR" rev-parse HEAD)"
+        if [ "$old_head" != "$expected_old_head" ]; then
+            echo "Existing old checkout is at $old_head, expected $expected_old_head" >&2
+            exit 1
+        fi
+    else
+        git -C "$REPO_DIR" worktree add "$OLD_SNOW_DIR" "$OLD_COMMIT"
+    fi
+
+    build_bench_env "$BENCH_TMP_ROOT/old" "$OLD_SNOW_DIR"
+    run_bench "SNOW old ($expected_old_head)" "$BENCH_TMP_ROOT/old" legacy
+fi

--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -136,6 +136,8 @@ options = Options(sparsity=sp, derivatives=[ReverseAD(), ForwardAD()])  # revers
 nothing #hide
 ```
 
+The coloring algorithm can be selected with `coloring_algorithm` from SparseMatrixColorings, for example `Options(sparsity=sp, derivatives=[ReverseAD(), ForwardAD()], coloring_algorithm=SparseMatrixColorings.GreedyColoringAlgorithm(SparseMatrixColorings.SmallestLast()))`.
+
 Currently supported options are ReverseAD, or RevZyg for the gradient, and ForwardAD or FD for the Jacobian.
 
 You can also provide your own derivatives.  For sparse Jacobians there are a wide variety of possible use cases (structure you can take advantage of, mixed-mode AD, using a combination of analytic and AD, etc.), and so for best performance you may want to provide your own.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -10,7 +10,7 @@
 - Easy switching between various differentiation methods: ForwardDiff, ReverseDiff, Zygote, FiniteDiff (forward, central, complex step), and user-defined derivatives.
 - Derivative calculations are all non-allocating during optimization.
 - Outputs are also cached as applicable to avoid unnecessary function calls.
-- Methods are provided to help determine sparsity patterns, sparse Jacobians can be updated efficiently with SparseDiffTools (using graph coloring), and the sparsity structure is passed to the solvers.
+- Methods are provided to help determine sparsity patterns, sparse Jacobians can be updated efficiently with SparseMatrixColorings (using graph coloring), and the sparsity structure is passed to the solvers.
 
 
 **Documentation**:

--- a/src/SNOW.jl
+++ b/src/SNOW.jl
@@ -6,7 +6,7 @@ using ReverseDiff
 using DiffResults
 using FiniteDiff
 using SparseArrays
-using SparseDiffTools
+using SparseMatrixColorings
 using Requires
 using Ipopt
 

--- a/src/SNOW.jl
+++ b/src/SNOW.jl
@@ -1,6 +1,7 @@
 module SNOW
 
 using ForwardDiff
+using DifferentiationInterface
 using ReverseDiff
 # using Zygote
 using DiffResults

--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -506,85 +506,20 @@ Cache for sparse jacobian using ForwardDiff
 """
 function sparsejacobiancache(sp::SparsePattern, dtype::ForwardAD, func!, nx, ng)
 
-    Jsp = sparse(sp.rows, sp.cols, ones(length(sp.rows)))
-    Jwork = copy(Jsp)
-    fill!(nonzeros(Jwork), zero(eltype(Jwork)))
-    colors = SparseMatrixColorings.fast_coloring(
-        Jsp,
-        SparseMatrixColorings.ColoringProblem(; structure = :nonsymmetric, partition = :column),
-        SparseMatrixColorings.GreedyColoringAlgorithm(),
+    Jsp = sparse(sp.rows, sp.cols, ones(length(sp.rows)), ng, nx)
+    Jwork = sparse(sp.rows, sp.cols, zeros(length(sp.rows)), ng, nx)
+    backend = DifferentiationInterface.AutoSparse(
+        DifferentiationInterface.AutoForwardDiff();
+        sparsity_detector = DifferentiationInterface.ADTypes.KnownJacobianSparsityDetector(Jsp),
+        coloring_algorithm = SparseMatrixColorings.GreedyColoringAlgorithm(),
     )
-    ncolor = isempty(colors) ? 0 : maximum(colors)
-
-    x0 = zeros(nx)
-    T = eltype(x0)
-    if ncolor == 0
-        cache = (
-            x0 = x0,
-            colorvec = colors,
-            color_partials = Vector{Vector{NTuple{1,T}}}(undef, 0),
-            chunksize = 0,
-            maxcolor = 0,
-            t = similar(x0),
-            fwork = similar(x0, ng),
-            dx = zeros(eltype(x0), ng),
-            ncols = nx,
-        )
-        return GradOrJacCache(func!, Jwork, cache, dtype)
-    end
-
-    chunksize = ForwardDiff.pickchunksize(ncolor)
-    color_partials = _generate_chunked_partials(colors, ncolor, chunksize, T)
-    tag = typeof(ForwardDiff.Tag(func!, eltype(x0)))
-    DT = ForwardDiff.Dual{tag,eltype(x0),chunksize}
-    t = similar(x0, DT)
-    partial_i = color_partials[1]
-    for i in eachindex(t)
-        t[i] = DT(x0[i], ForwardDiff.Partials(partial_i[i]))
-    end
-
-    fwork = similar(t, ng)
-
     cache = (
-        x0 = x0,
-        colorvec = colors,
-        color_partials = color_partials,
-        chunksize = chunksize,
-        maxcolor = ncolor,
-        t = t,
-        fwork = fwork,
-        dx = zeros(eltype(x0), ng),
-        ncols = nx,
+        prep = DifferentiationInterface.prepare_jacobian(func!, zeros(ng), backend, zeros(nx)),
+        backend = backend,
+        y = zeros(ng),
     )
 
     return GradOrJacCache(func!, Jwork, cache, dtype)
-end
-
-
-@generated function _partials_view_tup(partials, j, i, ::Val{chunksize}) where {chunksize}
-    :(Base.@ntuple $chunksize k -> partials[j, (i - 1) * $chunksize + k])
-end
-
-function _generate_chunked_partials(colorvec, ncolor::Int, chunksize::Int, ::Type{T}) where {T}
-    maxcolor = ncolor
-    num_of_chunks = cld(maxcolor, chunksize)
-    padding_size = (chunksize - (maxcolor % chunksize)) % chunksize
-    partials = Matrix{T}(undef, length(colorvec), maxcolor + padding_size)
-    fill!(partials, zero(T))
-    for i in eachindex(colorvec)
-        partials[i, colorvec[i]] = one(T)
-    end
-
-    chunked_partials = Vector{Vector{NTuple{chunksize, T}}}(undef, num_of_chunks)
-    for i in 1:num_of_chunks
-        tmp = Vector{NTuple{chunksize, T}}(undef, size(partials, 1))
-        for j in 1:size(partials, 1)
-            tmp[j] = _partials_view_tup(partials, j, i, Val(chunksize))
-        end
-        chunked_partials[i] = tmp
-    end
-
-    return chunked_partials
 end
 
 
@@ -601,45 +536,14 @@ evaluate sparse jacobian using ForwardDiff
 function sparsejacobian!(dg, x, cache::GradOrJacCache{T1,T2,T3,T4}
     where {T1,T2,T3,T4<:ForwardAD})
 
-    copyto!(cache.cache.x0, x)
-    cachei = cache.cache
-    f = cache.f!
-    Jwork = cache.work
-    fill!(nonzeros(Jwork), zero(eltype(Jwork)))
-    if cachei.maxcolor == 0
-        dg[:] = Jwork.nzval
-        return nothing
-    end
-
-    color_i = 1
-    vecx = cachei.x0
-    colorvec = cachei.colorvec
-    p = cachei.color_partials
-    t = cachei.t
-    fwork = cachei.fwork
-    dx = cachei.dx
-    for i in eachindex(p)
-        partial_i = p[i]
-        for j in eachindex(t)
-            t[j] = eltype(t)(vecx[j], ForwardDiff.Partials(partial_i[j]))
-        end
-        f(fwork, t)
-        for j in 1:cachei.chunksize
-            for k in eachindex(dx)
-                dx[k] = ForwardDiff.partials(fwork[k], j)
-            end
-            FiniteDiff._colorediteration!(
-                Jwork,
-                dx,
-                colorvec,
-                color_i,
-                cachei.ncols,
-            )
-            color_i += 1
-            color_i > cachei.maxcolor && break
-        end
-        color_i > cachei.maxcolor && break
-    end
+    DifferentiationInterface.jacobian!(
+        cache.f!,
+        cache.cache.y,
+        cache.work,
+        cache.cache.prep,
+        cache.cache.backend,
+        x,
+    )
     dg[:] = cache.work.nzval
 
     return nothing
@@ -701,23 +605,12 @@ Cache for sparse jacobian using finite differencing
 function sparsejacobiancache(sp::SparsePattern, dtype::FD, func!, nx, ng)
 
     x = zeros(nx)
-    Jsp = sparse(sp.rows, sp.cols, ones(length(sp.rows)), ng, nx)
+    Jwork = sparse(sp.rows, sp.cols, zeros(length(sp.rows)), ng, nx)
     fdtype = finitediff_type(dtype)
-    colors = SparseMatrixColorings.fast_coloring(
-        Jsp,
-        SparseMatrixColorings.ColoringProblem(; structure = :nonsymmetric, partition = :column),
-        SparseMatrixColorings.GreedyColoringAlgorithm(),
-    )
+    fcache = FiniteDiff.JacobianCache(x, zeros(ng), fdtype, sparsity = Jwork)
+    cache = (fcache = fcache,)
 
-    fcache = FiniteDiff.JacobianCache(x, zeros(ng), fdtype, colorvec = colors, sparsity = Jsp)
-    cache = (
-        Jwork = zeros(ng, nx),
-        rows = sp.rows,
-        cols = sp.cols,
-        fcache = fcache,
-    )
-
-    return GradOrJacCache(func!, Jsp, cache, dtype)
+    return GradOrJacCache(func!, Jwork, cache, dtype)
 end
 
 
@@ -734,11 +627,7 @@ evaluate sparse jacobian using finite differencing
 function sparsejacobian!(dg, x, cache::GradOrJacCache{T1,T2,T3,T4}
     where {T1,T2,T3,T4<:FD})
 
-    FiniteDiff.finite_difference_jacobian!(cache.cache.Jwork, cache.f!, x, cache.cache.fcache)
-
-    for i in eachindex(cache.work.nzval)
-        cache.work.nzval[i] = cache.cache.Jwork[cache.cache.rows[i], cache.cache.cols[i]]
-    end
+    FiniteDiff.finite_difference_jacobian!(cache.work, cache.f!, x, cache.cache.fcache)
     dg[:] = cache.work.nzval
     
     return nothing

--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -506,13 +506,85 @@ Cache for sparse jacobian using ForwardDiff
 """
 function sparsejacobiancache(sp::SparsePattern, dtype::ForwardAD, func!, nx, ng)
 
-    g = zeros(ng)
-    x = zeros(nx)
     Jsp = sparse(sp.rows, sp.cols, ones(length(sp.rows)))
-    colors = SparseDiffTools.matrix_colors(Jsp)
-    cachesp = SparseDiffTools.ForwardColorJacCache(func!, x, dx=g, colorvec=colors, sparsity=Jsp)
+    Jwork = copy(Jsp)
+    fill!(nonzeros(Jwork), zero(eltype(Jwork)))
+    colors = SparseMatrixColorings.fast_coloring(
+        Jsp,
+        SparseMatrixColorings.ColoringProblem(; structure = :nonsymmetric, partition = :column),
+        SparseMatrixColorings.GreedyColoringAlgorithm(),
+    )
+    ncolor = isempty(colors) ? 0 : maximum(colors)
 
-    return GradOrJacCache(func!, Jsp, cachesp, dtype)
+    x0 = zeros(nx)
+    T = eltype(x0)
+    if ncolor == 0
+        cache = (
+            x0 = x0,
+            colorvec = colors,
+            color_partials = Vector{Vector{NTuple{1,T}}}(undef, 0),
+            chunksize = 0,
+            maxcolor = 0,
+            t = similar(x0),
+            fwork = similar(x0, ng),
+            dx = zeros(eltype(x0), ng),
+            ncols = nx,
+        )
+        return GradOrJacCache(func!, Jwork, cache, dtype)
+    end
+
+    chunksize = ForwardDiff.pickchunksize(ncolor)
+    color_partials = _generate_chunked_partials(colors, ncolor, chunksize, T)
+    tag = typeof(ForwardDiff.Tag(func!, eltype(x0)))
+    DT = ForwardDiff.Dual{tag,eltype(x0),chunksize}
+    t = similar(x0, DT)
+    partial_i = color_partials[1]
+    for i in eachindex(t)
+        t[i] = DT(x0[i], ForwardDiff.Partials(partial_i[i]))
+    end
+
+    fwork = similar(t, ng)
+
+    cache = (
+        x0 = x0,
+        colorvec = colors,
+        color_partials = color_partials,
+        chunksize = chunksize,
+        maxcolor = ncolor,
+        t = t,
+        fwork = fwork,
+        dx = zeros(eltype(x0), ng),
+        ncols = nx,
+    )
+
+    return GradOrJacCache(func!, Jwork, cache, dtype)
+end
+
+
+@generated function _partials_view_tup(partials, j, i, ::Val{chunksize}) where {chunksize}
+    :(Base.@ntuple $chunksize k -> partials[j, (i - 1) * $chunksize + k])
+end
+
+function _generate_chunked_partials(colorvec, ncolor::Int, chunksize::Int, ::Type{T}) where {T}
+    maxcolor = ncolor
+    num_of_chunks = cld(maxcolor, chunksize)
+    padding_size = (chunksize - (maxcolor % chunksize)) % chunksize
+    partials = Matrix{T}(undef, length(colorvec), maxcolor + padding_size)
+    fill!(partials, zero(T))
+    for i in eachindex(colorvec)
+        partials[i, colorvec[i]] = one(T)
+    end
+
+    chunked_partials = Vector{Vector{NTuple{chunksize, T}}}(undef, num_of_chunks)
+    for i in 1:num_of_chunks
+        tmp = Vector{NTuple{chunksize, T}}(undef, size(partials, 1))
+        for j in 1:size(partials, 1)
+            tmp[j] = _partials_view_tup(partials, j, i, Val(chunksize))
+        end
+        chunked_partials[i] = tmp
+    end
+
+    return chunked_partials
 end
 
 
@@ -528,8 +600,46 @@ evaluate sparse jacobian using ForwardDiff
 """
 function sparsejacobian!(dg, x, cache::GradOrJacCache{T1,T2,T3,T4}
     where {T1,T2,T3,T4<:ForwardAD})
-    
-    SparseDiffTools.forwarddiff_color_jacobian!(cache.work, cache.f!, x, cache.cache)
+
+    copyto!(cache.cache.x0, x)
+    cachei = cache.cache
+    f = cache.f!
+    Jwork = cache.work
+    fill!(nonzeros(Jwork), zero(eltype(Jwork)))
+    if cachei.maxcolor == 0
+        dg[:] = Jwork.nzval
+        return nothing
+    end
+
+    color_i = 1
+    vecx = cachei.x0
+    colorvec = cachei.colorvec
+    p = cachei.color_partials
+    t = cachei.t
+    fwork = cachei.fwork
+    dx = cachei.dx
+    for i in eachindex(p)
+        partial_i = p[i]
+        for j in eachindex(t)
+            t[j] = eltype(t)(vecx[j], ForwardDiff.Partials(partial_i[j]))
+        end
+        f(fwork, t)
+        for j in 1:cachei.chunksize
+            for k in eachindex(dx)
+                dx[k] = ForwardDiff.partials(fwork[k], j)
+            end
+            FiniteDiff._colorediteration!(
+                Jwork,
+                dx,
+                colorvec,
+                color_i,
+                cachei.ncols,
+            )
+            color_i += 1
+            color_i > cachei.maxcolor && break
+        end
+        color_i > cachei.maxcolor && break
+    end
     dg[:] = cache.work.nzval
 
     return nothing
@@ -579,7 +689,7 @@ end
 # end
 
 """
-    sparsejacobiancache(sp::SparsePattern, dtype::ForwardAD, func!, nx, ng)
+    sparsejacobiancache(sp::SparsePattern, dtype::FD, func!, nx, ng)
 
 Cache for sparse jacobian using finite differencing
 
@@ -590,12 +700,22 @@ Cache for sparse jacobian using finite differencing
 """
 function sparsejacobiancache(sp::SparsePattern, dtype::FD, func!, nx, ng)
 
-    g = zeros(ng)
     x = zeros(nx)
-    Jsp = sparse(sp.rows, sp.cols, ones(length(sp.rows)))
-    colors = SparseDiffTools.matrix_colors(Jsp)
+    Jsp = sparse(sp.rows, sp.cols, ones(length(sp.rows)), ng, nx)
     fdtype = finitediff_type(dtype)
-    cache = FiniteDiff.JacobianCache(x, fdtype, colorvec=colors, sparsity=Jsp)
+    colors = SparseMatrixColorings.fast_coloring(
+        Jsp,
+        SparseMatrixColorings.ColoringProblem(; structure = :nonsymmetric, partition = :column),
+        SparseMatrixColorings.GreedyColoringAlgorithm(),
+    )
+
+    fcache = FiniteDiff.JacobianCache(x, zeros(ng), fdtype, colorvec = colors, sparsity = Jsp)
+    cache = (
+        Jwork = zeros(ng, nx),
+        rows = sp.rows,
+        cols = sp.cols,
+        fcache = fcache,
+    )
 
     return GradOrJacCache(func!, Jsp, cache, dtype)
 end
@@ -614,7 +734,11 @@ evaluate sparse jacobian using finite differencing
 function sparsejacobian!(dg, x, cache::GradOrJacCache{T1,T2,T3,T4}
     where {T1,T2,T3,T4<:FD})
 
-    FiniteDiff.finite_difference_jacobian!(cache.work, cache.f!, x, cache.cache)
+    FiniteDiff.finite_difference_jacobian!(cache.cache.Jwork, cache.f!, x, cache.cache.fcache)
+
+    for i in eachindex(cache.work.nzval)
+        cache.work.nzval[i] = cache.cache.Jwork[cache.cache.rows[i], cache.cache.cols[i]]
+    end
     dg[:] = cache.work.nzval
     
     return nothing

--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -504,14 +504,15 @@ Cache for sparse jacobian using ForwardDiff
 - `nx::Int`: number of design variables
 - `ng::Int`: number of constraints
 """
-function sparsejacobiancache(sp::SparsePattern, dtype::ForwardAD, func!, nx, ng)
+function sparsejacobiancache(sp::SparsePattern, dtype::ForwardAD, func!, nx, ng;
+    coloring_algorithm=SparseMatrixColorings.GreedyColoringAlgorithm())
 
     Jsp = sparse(sp.rows, sp.cols, ones(length(sp.rows)), ng, nx)
     Jwork = sparse(sp.rows, sp.cols, zeros(length(sp.rows)), ng, nx)
     backend = DifferentiationInterface.AutoSparse(
         DifferentiationInterface.AutoForwardDiff();
         sparsity_detector = DifferentiationInterface.ADTypes.KnownJacobianSparsityDetector(Jsp),
-        coloring_algorithm = SparseMatrixColorings.GreedyColoringAlgorithm(),
+        coloring_algorithm = coloring_algorithm,
     )
     cache = (
         prep = DifferentiationInterface.prepare_jacobian(func!, zeros(ng), backend, zeros(nx)),
@@ -602,12 +603,19 @@ Cache for sparse jacobian using finite differencing
 - `nx::Int`: number of design variables
 - `ng::Int`: number of constraints
 """
-function sparsejacobiancache(sp::SparsePattern, dtype::FD, func!, nx, ng)
+function sparsejacobiancache(sp::SparsePattern, dtype::FD, func!, nx, ng;
+    coloring_algorithm=SparseMatrixColorings.GreedyColoringAlgorithm())
 
     x = zeros(nx)
     Jwork = sparse(sp.rows, sp.cols, zeros(length(sp.rows)), ng, nx)
     fdtype = finitediff_type(dtype)
-    fcache = FiniteDiff.JacobianCache(x, zeros(ng), fdtype, sparsity = Jwork)
+    colors = SparseMatrixColorings.column_colors(SparseMatrixColorings.coloring(
+        Jwork,
+        SparseMatrixColorings.ColoringProblem(; structure = :nonsymmetric, partition = :column),
+        coloring_algorithm,
+    ))
+    fcache = FiniteDiff.JacobianCache(x, zeros(ng), fdtype,
+        colorvec=colors, sparsity=Jwork)
     cache = (fcache = fcache,)
 
     return GradOrJacCache(func!, Jwork, cache, dtype)
@@ -664,9 +672,11 @@ create cache for derivatives when the jacobian is sparse
 - `nx::Int`: number of design variables
 - `ng::Int`: number of constraints
 """
-function createcache(sp::SparsePattern, dtype::T, func!, nx, ng) where T<:Vector
+function createcache(sp::SparsePattern, dtype::T, func!, nx, ng;
+    coloring_algorithm=SparseMatrixColorings.GreedyColoringAlgorithm()) where T<:Vector
     gradcache = gradientcache(dtype[1], func!, nx, ng)
-    jaccache = sparsejacobiancache(sp, dtype[2], func!, nx, ng)
+    jaccache = sparsejacobiancache(sp, dtype[2], func!, nx, ng;
+        coloring_algorithm=coloring_algorithm)
 
     return SparseCache(gradcache, jaccache)
 end
@@ -704,7 +714,8 @@ Cache for sparse jacobian with user-supplied derivatives
 - `nx::Int`: number of design variables
 - `ng::Int`: number of constraints
 """
-function createcache(sp::SparsePattern, dtype::UserDeriv, func!, nx, ng)
+function createcache(sp::SparsePattern, dtype::UserDeriv, func!, nx, ng;
+    coloring_algorithm=SparseMatrixColorings.GreedyColoringAlgorithm())
     return GradOrJacCache(func!, 0.0, nothing, dtype)
 end
 
@@ -726,4 +737,3 @@ function evaluate!(g, df, dg, x, cache::GradOrJacCache{T1,T2,T3,T4}
     
     return f
 end
-

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -9,7 +9,8 @@ function optimize(solver::AbstractSolver, cache, x0, lx, ux, lg, ug, rows, cols)
 end
 
 """
-    Options(;sparsity=DensePattern(), derivatives=ForwardFD(), solver=IPOPT())
+    Options(;sparsity=DensePattern(), derivatives=ForwardFD(), solver=IPOPT(),
+        coloring_algorithm=SparseMatrixColorings.GreedyColoringAlgorithm())
 
 Options for SNOW.  Default is dense, forward finite differencing, and IPOPT.
 
@@ -19,16 +20,22 @@ Options for SNOW.  Default is dense, forward finite differencing, and IPOPT.
     or `derivatives::Vector{AbstractDiffMethod}`: vector of length two, 
     first for gradient differentiation method, second for jacobian differentiation method
 - `solver::AbstractSolver`: specificy which optimizer to use
+- `coloring_algorithm`: algorithm used for sparse Jacobian coloring
 """
-struct Options{T1,T2,T3}
+struct Options{T1,T2,T3,T4}
     sparsity::T1  # AbstractSparsityPattern
     derivatives::T2  # AbstractDiffMethod
     solver::T3  # AbstractSolver
+    coloring_algorithm::T4
 end
 
+Options(sparsity, derivatives, solver) =
+    Options(sparsity, derivatives, solver, SparseMatrixColorings.GreedyColoringAlgorithm())
+
 # defaults
-Options(; sparsity=DensePattern(), derivatives=ForwardFD(), solver=IPOPT()
-    ) = Options(sparsity, derivatives, solver)
+Options(; sparsity=DensePattern(), derivatives=ForwardFD(), solver=IPOPT(),
+    coloring_algorithm=SparseMatrixColorings.GreedyColoringAlgorithm()
+    ) = Options(sparsity, derivatives, solver, coloring_algorithm)
 
 
 # private convenience method to size bounds of length 1 to required length
@@ -64,7 +71,12 @@ function minimize(func!, x0, ng, lx=-Inf, ux=Inf, lg=-Inf, ug=0.0, options=Optio
     ug = resizebounds(ug, ng)
     
     # create cache
-    cache = createcache(options.sparsity, options.derivatives, func!, nx, ng)
+    cache = if options.sparsity isa SparsePattern
+        createcache(options.sparsity, options.derivatives, func!, nx, ng;
+            coloring_algorithm=options.coloring_algorithm)
+    else
+        createcache(options.sparsity, options.derivatives, func!, nx, ng)
+    end
 
     # determine sparsity pattern
     rows, cols = getsparsity(options.sparsity, nx, ng)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,3 +1,4 @@
 [deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,3 @@
 [deps]
-BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using SNOW
 using Test
 using Zygote
+using BenchmarkTools
 
 checkallocations = false
 snopttest = false
@@ -63,6 +64,69 @@ SNOW.evaluate!(g, df, dg, x, cache)
 
 @test df == [2*x[1]; -1.0]
 @test dg == [-2.0, 2*x[1], 1.0, -1.0]
+
+# sparse with reverse and finite-difference
+for fd in (ForwardFD(), CentralFD(), ComplexStep())
+    dg = zeros(length(sp.rows))
+    cache = SNOW.createcache(sp, [ReverseAD(), fd], test1!, nx, ng)
+    SNOW.evaluate!(g, df, dg, x, cache)
+
+    @test isapprox(df, [2*x[1]; -1.0])
+    @test isapprox(dg, [-2.0, 2*x[1], 1.0, -1.0])
+end
+
+function benchstats(g, df, dg, x, cache)
+    bench = @benchmark SNOW.evaluate!($g, $df, $dg, $x, $cache) samples=2000
+    t = sort(Float64.(bench.times) ./ 1e3)
+    n = length(t)
+    return (
+        n = n,
+        min = t[1],
+        median = t[cld(n, 2)],
+        p90 = t[clamp(Int(ceil(0.90 * n)), 1, n)],
+        p95 = t[clamp(Int(ceil(0.95 * n)), 1, n)],
+        p99 = t[clamp(Int(ceil(0.99 * n)), 1, n)],
+        max = t[end],
+    )
+end
+
+bench_median_reference_us = (
+    ad = (n = 2000, min = 1.0, median = 1.125, p90 = 1.167, p95 = 1.208, p99 = 1.25, max = 18.292),
+    fd = (n = 2000, min = 0.959, median = 1.084, p90 = 1.167, p95 = 1.167, p99 = 1.25, max = 15.5),
+    cd = (n = 2000, min = 1.0, median = 1.084, p90 = 1.166, p95 = 1.167, p99 = 1.25, max = 20.583),
+    cs = (n = 2000, min = 0.958, median = 1.042, p90 = 1.125, p95 = 1.125, p99 = 1.208, max = 15.416),
+)
+
+bench_median_limits_us = (
+    ad = 2 * bench_median_reference_us.ad.median,
+    fd = 2 * bench_median_reference_us.fd.median,
+    cd = 2 * bench_median_reference_us.cd.median,
+    cs = 2 * bench_median_reference_us.cs.median,
+)
+
+function assert_benchstats(stats, max_median)
+    @test stats.n > 0
+    @test stats.min > 0
+    @test stats.min <= stats.median <= stats.p90 <= stats.p95 <= stats.p99 <= stats.max
+    @test stats.median <= max_median
+end
+
+function assert_runtime_order(stats_ad, stats_fd, stats_cd, stats_cs)
+    # keep comparisons loose enough for shared CI nodes but still catch regressions
+    @test stats_ad.median * 50 >= stats_fd.median
+    @test stats_ad.median * 50 >= stats_cd.median
+    @test stats_ad.median * 50 >= stats_cs.median
+end
+
+sparse_bench_ad = benchstats(g, df, dg, x, SNOW.createcache(sp, [ReverseAD(), ForwardAD()], test1!, nx, ng))
+sparse_bench_fd = benchstats(g, df, dg, x, SNOW.createcache(sp, [ReverseAD(), ForwardFD()], test1!, nx, ng))
+sparse_bench_cd = benchstats(g, df, dg, x, SNOW.createcache(sp, [ReverseAD(), CentralFD()], test1!, nx, ng))
+sparse_bench_cs = benchstats(g, df, dg, x, SNOW.createcache(sp, [ReverseAD(), ComplexStep()], test1!, nx, ng))
+assert_benchstats(sparse_bench_ad, bench_median_limits_us.ad)
+assert_benchstats(sparse_bench_fd, bench_median_limits_us.fd)
+assert_benchstats(sparse_bench_cd, bench_median_limits_us.cd)
+assert_benchstats(sparse_bench_cs, bench_median_limits_us.cs)
+assert_runtime_order(sparse_bench_ad, sparse_bench_fd, sparse_bench_cd, sparse_bench_cs)
 
 # # sparse with zygote and forward
 # dg = zeros(length(sp.rows))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,7 @@
 using SNOW
 using Test
 using Zygote
-using BenchmarkTools
 
-checkallocations = false
 snopttest = false
 
 @testset "derivatives" begin
@@ -75,58 +73,25 @@ for fd in (ForwardFD(), CentralFD(), ComplexStep())
     @test isapprox(dg, [-2.0, 2*x[1], 1.0, -1.0])
 end
 
-function benchstats(g, df, dg, x, cache)
-    bench = @benchmark SNOW.evaluate!($g, $df, $dg, $x, $cache) samples=2000
-    t = sort(Float64.(bench.times) ./ 1e3)
-    n = length(t)
-    return (
-        n = n,
-        min = t[1],
-        median = t[cld(n, 2)],
-        p90 = t[clamp(Int(ceil(0.90 * n)), 1, n)],
-        p95 = t[clamp(Int(ceil(0.95 * n)), 1, n)],
-        p99 = t[clamp(Int(ceil(0.99 * n)), 1, n)],
-        max = t[end],
-    )
-end
-
-bench_median_reference_us = (
-    ad = (n = 2000, min = 1.0, median = 1.125, p90 = 1.167, p95 = 1.208, p99 = 1.25, max = 18.292),
-    fd = (n = 2000, min = 0.959, median = 1.084, p90 = 1.167, p95 = 1.167, p99 = 1.25, max = 15.5),
-    cd = (n = 2000, min = 1.0, median = 1.084, p90 = 1.166, p95 = 1.167, p99 = 1.25, max = 20.583),
-    cs = (n = 2000, min = 0.958, median = 1.042, p90 = 1.125, p95 = 1.125, p99 = 1.208, max = 15.416),
+for algorithm in (
+    SNOW.SparseMatrixColorings.GreedyColoringAlgorithm(),
+    SNOW.SparseMatrixColorings.GreedyColoringAlgorithm(
+        SNOW.SparseMatrixColorings.SmallestLast()),
+    SNOW.SparseMatrixColorings.ConstantColoringAlgorithm(ones(ng, nx), [1, 2]),
 )
-
-bench_median_limits_us = (
-    ad = 2 * bench_median_reference_us.ad.median,
-    fd = 2 * bench_median_reference_us.fd.median,
-    cd = 2 * bench_median_reference_us.cd.median,
-    cs = 2 * bench_median_reference_us.cs.median,
-)
-
-function assert_benchstats(stats, max_median)
-    @test stats.n > 0
-    @test stats.min > 0
-    @test stats.min <= stats.median <= stats.p90 <= stats.p95 <= stats.p99 <= stats.max
-    @test stats.median <= max_median
+    for dtype in (ForwardAD(), ForwardFD())
+        dg = zeros(length(sp.rows))
+        cache = SNOW.createcache(sp, [ReverseAD(), dtype], test1!, nx, ng;
+            coloring_algorithm=algorithm)
+        SNOW.evaluate!(g, df, dg, x, cache)
+        @test isapprox(dg, [-2.0, 2*x[1], 1.0, -1.0])
+    end
 end
 
-function assert_runtime_order(stats_ad, stats_fd, stats_cd, stats_cs)
-    # keep comparisons loose enough for shared CI nodes but still catch regressions
-    @test stats_ad.median * 50 >= stats_fd.median
-    @test stats_ad.median * 50 >= stats_cd.median
-    @test stats_ad.median * 50 >= stats_cs.median
-end
-
-sparse_bench_ad = benchstats(g, df, dg, x, SNOW.createcache(sp, [ReverseAD(), ForwardAD()], test1!, nx, ng))
-sparse_bench_fd = benchstats(g, df, dg, x, SNOW.createcache(sp, [ReverseAD(), ForwardFD()], test1!, nx, ng))
-sparse_bench_cd = benchstats(g, df, dg, x, SNOW.createcache(sp, [ReverseAD(), CentralFD()], test1!, nx, ng))
-sparse_bench_cs = benchstats(g, df, dg, x, SNOW.createcache(sp, [ReverseAD(), ComplexStep()], test1!, nx, ng))
-assert_benchstats(sparse_bench_ad, bench_median_limits_us.ad)
-assert_benchstats(sparse_bench_fd, bench_median_limits_us.fd)
-assert_benchstats(sparse_bench_cd, bench_median_limits_us.cd)
-assert_benchstats(sparse_bench_cs, bench_median_limits_us.cs)
-assert_runtime_order(sparse_bench_ad, sparse_bench_fd, sparse_bench_cd, sparse_bench_cs)
+options = Options(sparsity=sp, derivatives=[ReverseAD(), ForwardAD()],
+    coloring_algorithm=SNOW.SparseMatrixColorings.GreedyColoringAlgorithm(
+        SNOW.SparseMatrixColorings.SmallestLast()))
+@test options.coloring_algorithm isa SNOW.SparseMatrixColorings.GreedyColoringAlgorithm
 
 # # sparse with zygote and forward
 # dg = zeros(length(sp.rows))
@@ -140,48 +105,6 @@ assert_runtime_order(sparse_bench_ad, sparse_bench_fd, sparse_bench_cd, sparse_b
 
 end
 
-# if checkallocations
-# # -------- test allocations --------------
-#     using BenchmarkTools
-
-#     function test2!(g, x)
-#         f = x[1]^2 - x[2]
-        
-#         Zygote.ignore() do
-#             nx = length(x)
-#             for i = 1:nx
-#                 g[i] = x[i]^2
-#             end
-#             g[nx+1:end] .= x[1]
-#         end
-#         return f
-#     end
-
-#     nx = 300
-#     ng = 500
-#     g = zeros(ng)
-#     df = zeros(nx)
-#     dg = zeros(ng*nx)
-#     x = 2*ones(nx)
-#     cache = SNOW.createcache(DensePattern(), ForwardAD(), test2!, nx, ng)
-#     @btime SNOW.evaluate!($g, $df, $dg, $x, $cache)
-#     # 577.123 μs (6 allocations: 2.30 MiB)
-
-#     cache = SNOW.createcache(DensePattern(), ReverseAD(), test2!, nx, ng)
-#     @btime SNOW.evaluate!($g, $df, $dg, $x, $cache)
-#     # 4.188 ms (6 allocations: 2.30 MiB)
-
-#     cache = SNOW.createcache(DensePattern(), FD("forward"), test2!, nx, ng)
-#     @btime SNOW.evaluate!($g, $df, $dg, $x, $cache)
-#     # 358.457 μs (6 allocations: 2.30 MiB)
-
-#     lx = -5*ones(nx)
-#     ux = 5*ones(nx)
-#     sp = SparsePattern(ForwardAD(), test2!, ng, lx, ux)
-#     dg = zeros(length(sp.rows))
-#     cache = SNOW.createcache(sp, [ReverseAD(), ForwardAD()], test2!, nx, ng)
-#     @btime SNOW.evaluate!($g, $df, $dg, $x, $cache)
-#     # 17.391 μs (0 allocations: 0 bytes)
 
 #     cache = SNOW.createcache(sp, [RevZyg(), ForwardAD()], test2!, nx, ng)
 #     @btime SNOW.evaluate!($g, $df, $dg, $x, $cache)


### PR DESCRIPTION
SparseDiffTools.jl is depreciated & causing compat issues, replaced with SparseMatrixColoring.jl.  Doing it simply ended up with a 10x performance hit until a chunking method was used.

**Please note that this was vibe coded;** changes were encouraged to be as simple as possible while still passing the original tests and a performance benchmark on the sparse-handling portions of the code.  

```

SNOW.jl pre-change benchmarking:
AD: min=122.542μs, p5=123.916μs, median=131.125μs, p90=134.750μs, p95=136.084μs, p99=143.000μs, max=175.792μs
FD: min=124.375μs, p5=126.209μs, median=131.875μs, p90=135.792μs, p95=137.333μs, p99=143.166μs, max=158.250μs
CS: min=123.417μs, p5=124.917μs, median=126.417μs, p90=134.917μs, p95=135.583μs, p99=137.084μs, max=162.208μs

SNOW.jl post-change benchmarking:
AD: min=120.833μs, p5=123.25μs, median=125.416μs, p90=134.833μs, p95=136.458μs, p99=149.625μs, max=245.958μs
FD: min=129.083μs, p5=130.792μs, median=137.209μs, p90=152.000μs, p95=157.583μs, p99=188.208μs, max=488.208μs
CS: min=129.542μs, p5=131.500μs, median=138.542μs, p90=147.083μs, p95=152.875μs, p99=157.667μs, max=318.792μs
```
