### PR TITLE
Named coloring presets, struct-field coloring_algorithm API, expanded tests/docs, real-world benchmark

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Andrew Ning <aning@byu.edu> and contributors"]
 version = "1.0.0"
 
 [deps]
+ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 DiffResults = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"
 DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
@@ -15,6 +16,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SparseMatrixColorings = "0a514795-09f3-496d-8182-132a7b665d35"
 
 [compat]
+ADTypes = "1.22"
 DiffResults = "1.0"
 DifferentiationInterface = "0.7.20"
 FiniteDiff = "2.8"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SNOW"
 uuid = "105f6ee8-0889-46b1-9d4b-65e03cbc8f13"
 authors = ["Andrew Ning <aning@byu.edu> and contributors"]
-version = "0.3.2"
+version = "1.0.0"
 
 [deps]
 DiffResults = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,7 +1,5 @@
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
-MatrixDepot = "b51810bb-c9f3-55da-ae3c-350fc1fbce05"
 PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SNOW = "105f6ee8-0889-46b1-9d4b-65e03cbc8f13"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,4 +1,7 @@
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+MatrixDepot = "b51810bb-c9f3-55da-ae3c-350fc1fbce05"
 PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SNOW = "105f6ee8-0889-46b1-9d4b-65e03cbc8f13"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -17,3 +17,14 @@ benchmark environment is defined in [`Project.toml`](Project.toml).
 
 The runner prints the full timing summary for every derivative mode and
 coloring-algorithm permutation.
+
+## Real-world sparse Jacobian benchmark
+
+[`sparse_jacobian_bench.jl`](sparse_jacobian_bench.jl) complements the above
+with a handful of synthetic problems (tridiagonal, 2D Laplacian, worst-case
+coloring, non-square) benchmarked across all four differentiation methods
+(AD, forward/central FD, complex step):
+
+```bash
+julia --project=benchmark benchmark/sparse_jacobian_bench.jl
+```

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -61,14 +61,15 @@ function make_benchmark(dmode::Symbol, algorithm::Symbol)
     df = zeros(nx)
     sp = make_pattern(nx)
     dg = zeros(length(sp.rows))
-    method = dmode == :fd ? [SNOW.ReverseAD(), SNOW.ForwardFD()] : [SNOW.ReverseAD(), SNOW.ForwardAD()]
-
-    cache = if algorithm == :legacy
-        SNOW.createcache(sp, method, test2!, nx, ng)
+    method = if algorithm == :legacy
+        dmode == :fd ? [SNOW.ReverseAD(), SNOW.ForwardFD()] : [SNOW.ReverseAD(), SNOW.ForwardAD()]
     else
-        SNOW.createcache(sp, method, test2!, nx, ng;
-            coloring_algorithm=coloring_algorithm(algorithm, nx))
+        alg = coloring_algorithm(algorithm, nx)
+        dmode == :fd ? [SNOW.ReverseAD(), SNOW.ForwardFD(coloring_algorithm=alg)] :
+            [SNOW.ReverseAD(), SNOW.ForwardAD(coloring_algorithm=alg)]
     end
+
+    cache = SNOW.createcache(sp, method, test2!, nx, ng)
 
     SNOW.evaluate!(g, df, dg, x, cache)
     return @benchmarkable SNOW.evaluate!($g, $df, $dg, $x, $cache) samples=BENCH_NSAMPLES evals=BENCH_NEVALS

--- a/benchmark/sparse_jacobian_bench.jl
+++ b/benchmark/sparse_jacobian_bench.jl
@@ -1,13 +1,13 @@
 #=
-Benchmark comparing sparse-Jacobian cache construction and evaluation cost.
-Run this same script against both the `master` branch (SparseDiffTools) and
-the `differentiation-interface` branch (DifferentiationInterface.jl +
-SparseMatrixColorings.jl) to compare them - see benchmark/README.md.
+Benchmark comparing sparse-Jacobian cache construction and evaluation cost,
+across all four differentiation methods (AD, forward/central FD, complex
+step). Run this same script against different commits/branches to compare
+them - see benchmark/README.md.
 
     julia --project=benchmark benchmark/sparse_jacobian_bench.jl
 =#
 
-using SNOW, SparseArrays, BenchmarkTools, Printf, MatrixDepot, Random
+using SNOW, SparseArrays, BenchmarkTools, Printf
 
 # ---------------------------------------------------------------------------
 # synthetic problems spanning coloring difficulty
@@ -60,53 +60,27 @@ function overdetermined!(g, x)
     return sum(abs2, x)
 end
 
-synthetic_problems = [
+problems = [
     ("tridiagonal_n2000", tridiagonal!, 2000, 2000),
     ("laplacian2d_n3600", (g, x) -> laplacian2d!(g, x, 60), 3600, 3600),
     ("arrowhead_n500", starfun!, 500, 500),
-    ("arrowhead_n2000", starfun!, 2000, 2000),
     ("nonsquare_nx2000_ng5000", overdetermined!, 2000, 5000),
 ]
-
-# ---------------------------------------------------------------------------
-# real-world sparsity patterns (SuiteSparse Matrix Collection via MatrixDepot)
-# only the nonzero pattern is real; we build a synthetic nonlinear residual
-# whose analytic Jacobian sparsity matches it exactly
-# ---------------------------------------------------------------------------
-
-function make_real_problem(name; seed=hash(name))
-    A = SparseMatrixCSC(matrixdepot(name))
-    n, m = size(A)
-    @assert n == m "expected a square matrix, got $(size(A)) for $name"
-    rows, cols, _ = findnz(A)
-    rng = MersenneTwister(seed % typemax(Int))
-    w = 0.5 .+ rand(rng, length(rows))
-    f! = function (g, x)
-        fill!(g, 0.0)
-        @inbounds for k in eachindex(rows)
-            i, j = rows[k], cols[k]
-            xj = x[j]
-            g[i] += w[k]*xj + 0.15*w[k]*xj^2
-        end
-        return sum(abs2, x)
-    end
-    return (replace(name, "/" => "_"), f!, n, n)
-end
-
-real_problems = [
-    make_real_problem("HB/orani678"),   # 2529x2529, economic CGE model, ~1100 colors (hard coloring)
-    make_real_problem("FIDAP/ex11"),    # 16614x16614, CFD finite-element, ~1.1M nnz
-]
-
-problems = vcat(synthetic_problems, real_problems)
 
 # ---------------------------------------------------------------------------
 # run
 # ---------------------------------------------------------------------------
 
-println(@sprintf("%-24s %8s %8s %10s | %12s %12s %10s",
-    "problem", "nx", "ng", "nnz", "cache setup", "eval", "eval bytes"))
-println(repeat("-", 90))
+methods = [
+    ("AD", ForwardAD()),
+    ("FD-forward", ForwardFD()),
+    ("FD-central", CentralFD()),
+    ("CS", ComplexStep()),
+]
+
+println(@sprintf("%-24s %-11s %8s %8s %10s | %12s %12s %10s",
+    "problem", "method", "nx", "ng", "nnz", "cache setup", "eval", "eval bytes"))
+println(repeat("-", 100))
 
 for (name, f!, nx, ng) in problems
     lx = -5.0*ones(nx)
@@ -114,12 +88,14 @@ for (name, f!, nx, ng) in problems
     sp = SparsePattern(ForwardAD(), f!, ng, lx, ux)
     x = collect(range(0.13, 1.87, length=nx))
 
-    t_setup = @belapsed SNOW.sparsejacobiancache($sp, ForwardAD(), $f!, $nx, $ng) samples=3 evals=1
-    cache = SNOW.sparsejacobiancache(sp, ForwardAD(), f!, nx, ng)
-    dg = zeros(length(sp.rows))
-    t_eval = @belapsed SNOW.sparsejacobian!($dg, $x, $cache) samples=10 evals=1
-    b_eval = @ballocated SNOW.sparsejacobian!($dg, $x, $cache) samples=10 evals=1
+    for (mname, dtype) in methods
+        t_setup = @belapsed SNOW.sparsejacobiancache($sp, $dtype, $f!, $nx, $ng) samples=20 evals=1
+        cache = SNOW.sparsejacobiancache(sp, dtype, f!, nx, ng)
+        dg = zeros(length(sp.rows))
+        t_eval = @belapsed SNOW.sparsejacobian!($dg, $x, $cache) samples=10 evals=1
+        b_eval = @ballocated SNOW.sparsejacobian!($dg, $x, $cache) samples=10 evals=1
 
-    println(@sprintf("%-24s %8d %8d %10d | %10.3fms %10.3fms %10dB",
-        name, nx, ng, length(sp.rows), t_setup*1e3, t_eval*1e3, b_eval))
+        println(@sprintf("%-24s %-11s %8d %8d %10d | %10.3fms %10.3fms %10dB",
+            name, mname, nx, ng, length(sp.rows), t_setup*1e3, t_eval*1e3, b_eval))
+    end
 end

--- a/benchmark/sparse_jacobian_bench.jl
+++ b/benchmark/sparse_jacobian_bench.jl
@@ -1,0 +1,125 @@
+#=
+Benchmark comparing sparse-Jacobian cache construction and evaluation cost.
+Run this same script against both the `master` branch (SparseDiffTools) and
+the `differentiation-interface` branch (DifferentiationInterface.jl +
+SparseMatrixColorings.jl) to compare them - see benchmark/README.md.
+
+    julia --project=benchmark benchmark/sparse_jacobian_bench.jl
+=#
+
+using SNOW, SparseArrays, BenchmarkTools, Printf, MatrixDepot, Random
+
+# ---------------------------------------------------------------------------
+# synthetic problems spanning coloring difficulty
+# ---------------------------------------------------------------------------
+
+function tridiagonal!(g, x)
+    n = length(x)
+    g[1] = x[1]^2 - 2x[2]
+    for i in 2:n-1
+        g[i] = x[i-1]*x[i] - x[i+1]^2 + sin(x[i])
+    end
+    g[n] = x[n]^2 - x[n-1]
+    return sum(abs2, x)
+end
+
+function laplacian2d!(g, x, m)
+    idx(i, j) = (i - 1) * m + j
+    for i in 1:m, j in 1:m
+        k = idx(i, j)
+        c = 4x[k]
+        c -= i > 1 ? x[idx(i-1,j)] : 0.0
+        c -= i < m ? x[idx(i+1,j)] : 0.0
+        c -= j > 1 ? x[idx(i,j-1)] : 0.0
+        c -= j < m ? x[idx(i,j+1)] : 0.0
+        g[k] = c + 0.01*x[k]^3
+    end
+    return sum(abs2, x)
+end
+
+# worst case for forward-mode coloring: g[1] depends on every x[i], so every
+# column conflicts with every other column -> ncolors == nx
+function starfun!(g, x)
+    n = length(x)
+    g[1] = sum(x)
+    for i in 2:n
+        g[i] = x[i]^2 + 0.1*x[1]
+    end
+    return sum(abs2, x)
+end
+
+# non-square (overdetermined): more constraints than variables
+function overdetermined!(g, x)
+    nx = length(x)
+    ng = length(g)
+    for i in 1:ng
+        j1 = ((i - 1) % nx) + 1
+        j2 = (i % nx) + 1
+        g[i] = 0.3*x[j1]^2 + (j2 != j1 ? 0.2*x[j2] : 0.0)
+    end
+    return sum(abs2, x)
+end
+
+synthetic_problems = [
+    ("tridiagonal_n2000", tridiagonal!, 2000, 2000),
+    ("laplacian2d_n3600", (g, x) -> laplacian2d!(g, x, 60), 3600, 3600),
+    ("arrowhead_n500", starfun!, 500, 500),
+    ("arrowhead_n2000", starfun!, 2000, 2000),
+    ("nonsquare_nx2000_ng5000", overdetermined!, 2000, 5000),
+]
+
+# ---------------------------------------------------------------------------
+# real-world sparsity patterns (SuiteSparse Matrix Collection via MatrixDepot)
+# only the nonzero pattern is real; we build a synthetic nonlinear residual
+# whose analytic Jacobian sparsity matches it exactly
+# ---------------------------------------------------------------------------
+
+function make_real_problem(name; seed=hash(name))
+    A = SparseMatrixCSC(matrixdepot(name))
+    n, m = size(A)
+    @assert n == m "expected a square matrix, got $(size(A)) for $name"
+    rows, cols, _ = findnz(A)
+    rng = MersenneTwister(seed % typemax(Int))
+    w = 0.5 .+ rand(rng, length(rows))
+    f! = function (g, x)
+        fill!(g, 0.0)
+        @inbounds for k in eachindex(rows)
+            i, j = rows[k], cols[k]
+            xj = x[j]
+            g[i] += w[k]*xj + 0.15*w[k]*xj^2
+        end
+        return sum(abs2, x)
+    end
+    return (replace(name, "/" => "_"), f!, n, n)
+end
+
+real_problems = [
+    make_real_problem("HB/orani678"),   # 2529x2529, economic CGE model, ~1100 colors (hard coloring)
+    make_real_problem("FIDAP/ex11"),    # 16614x16614, CFD finite-element, ~1.1M nnz
+]
+
+problems = vcat(synthetic_problems, real_problems)
+
+# ---------------------------------------------------------------------------
+# run
+# ---------------------------------------------------------------------------
+
+println(@sprintf("%-24s %8s %8s %10s | %12s %12s %10s",
+    "problem", "nx", "ng", "nnz", "cache setup", "eval", "eval bytes"))
+println(repeat("-", 90))
+
+for (name, f!, nx, ng) in problems
+    lx = -5.0*ones(nx)
+    ux = 5.0*ones(nx)
+    sp = SparsePattern(ForwardAD(), f!, ng, lx, ux)
+    x = collect(range(0.13, 1.87, length=nx))
+
+    t_setup = @belapsed SNOW.sparsejacobiancache($sp, ForwardAD(), $f!, $nx, $ng) samples=3 evals=1
+    cache = SNOW.sparsejacobiancache(sp, ForwardAD(), f!, nx, ng)
+    dg = zeros(length(sp.rows))
+    t_eval = @belapsed SNOW.sparsejacobian!($dg, $x, $cache) samples=10 evals=1
+    b_eval = @ballocated SNOW.sparsejacobian!($dg, $x, $cache) samples=10 evals=1
+
+    println(@sprintf("%-24s %8d %8d %10d | %10.3fms %10.3fms %10dB",
+        name, nx, ng, length(sp.rows), t_setup*1e3, t_eval*1e3, b_eval))
+end

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -1,139 +1,205 @@
 # This file is machine-generated - editing it directly is not advised
 
+[[ADTypes]]
+git-tree-sha1 = "ec6be48a85c93d995563b84bff8a86bc98df45ce"
+uuid = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
+version = "1.22.2"
+
+    [ADTypes.extensions]
+    ADTypesChainRulesCoreExt = "ChainRulesCore"
+    ADTypesConstructionBaseExt = "ConstructionBase"
+    ADTypesEnzymeCoreExt = "EnzymeCore"
+
+    [ADTypes.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
+    EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
+
 [[ASL_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "fc1716d806dd345db9fd82e93f2186771fe6df13"
+git-tree-sha1 = "6252039f98492252f9e47c312c8ffda0e3b9e78d"
 uuid = "ae81ac8f-d209-56e5-92de-9978fef736f9"
-version = "0.1.1+4"
-
-[[AbstractFFTs]]
-deps = ["LinearAlgebra"]
-git-tree-sha1 = "485ee0867925449198280d4af84bdb46a2a404d0"
-uuid = "621f4979-c628-5d54-868e-fcf4e3e8185c"
-version = "1.0.1"
+version = "0.1.3+0"
 
 [[Adapt]]
 deps = ["LinearAlgebra"]
-git-tree-sha1 = "ffcfa2d345aaee0ef3d8346a073d5dd03c983ebe"
+git-tree-sha1 = "daa72978cd7a624246e894a4f4f067706d4e17e2"
 uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
-version = "3.2.0"
+version = "4.7.0"
+weakdeps = ["SparseArrays", "StaticArrays"]
 
-[[ArnoldiMethod]]
-deps = ["LinearAlgebra", "Random", "StaticArrays"]
-git-tree-sha1 = "f87e559f87a45bece9c9ed97458d3afe98b1ebb9"
-uuid = "ec485272-7323-5ecc-a04f-4719b315124d"
-version = "0.1.0"
+    [Adapt.extensions]
+    AdaptSparseArraysExt = "SparseArrays"
+    AdaptStaticArraysExt = "StaticArrays"
+
+[[ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+version = "1.1.1"
 
 [[ArrayInterface]]
-deps = ["IfElse", "LinearAlgebra", "Requires", "SparseArrays", "Static"]
-git-tree-sha1 = "da557609446152beb6ee134683d7b79ece129eae"
+deps = ["Adapt", "LinearAlgebra"]
+git-tree-sha1 = "60f11b38ebeabd984f5535838d91e197d97202f0"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "3.1.5"
+version = "7.28.1"
+
+    [ArrayInterface.extensions]
+    ArrayInterfaceAMDGPUExt = "AMDGPU"
+    ArrayInterfaceBandedMatricesExt = "BandedMatrices"
+    ArrayInterfaceBlockBandedMatricesExt = "BlockBandedMatrices"
+    ArrayInterfaceCUDAExt = "CUDA"
+    ArrayInterfaceCUDSSExt = ["CUDSS", "CUDA"]
+    ArrayInterfaceChainRulesCoreExt = "ChainRulesCore"
+    ArrayInterfaceChainRulesExt = "ChainRules"
+    ArrayInterfaceFillArraysExt = "FillArrays"
+    ArrayInterfaceGPUArraysCoreExt = "GPUArraysCore"
+    ArrayInterfaceMetalExt = "Metal"
+    ArrayInterfaceReverseDiffExt = "ReverseDiff"
+    ArrayInterfaceSparseArraysExt = "SparseArrays"
+    ArrayInterfaceStaticArraysCoreExt = "StaticArraysCore"
+    ArrayInterfaceTrackerExt = "Tracker"
+
+    [ArrayInterface.weakdeps]
+    AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"
+    BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
+    BlockBandedMatrices = "ffab5731-97b5-5995-9138-79e8c1846df0"
+    CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+    CUDSS = "45b445bb-4962-46a0-9369-b4df9d0f772e"
+    ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
+    GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
+    Metal = "dde4c033-4e86-420c-a63e-0dd931031962"
+    ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+    StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+    Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 
 [[Artifacts]]
-deps = ["Pkg"]
-git-tree-sha1 = "c30985d8821e0cd73870b17b0ed0ce6dc44cb744"
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
-version = "1.3.0"
 
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
-[[BenchmarkTools]]
-deps = ["JSON", "Logging", "Printf", "Statistics", "UUIDs"]
-git-tree-sha1 = "9e62e66db34540a0c919d72172cc2f642ac71260"
-uuid = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
-version = "0.5.0"
-
-[[BinaryProvider]]
-deps = ["Libdl", "Logging", "SHA"]
-git-tree-sha1 = "ecdec412a9abc8db54c0efc5548c64dfce072058"
-uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
-version = "0.5.10"
-
-[[Bzip2_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "c3598e525718abcc440f69cc6d5f60dda0a1b61e"
-uuid = "6e34b625-4abd-537c-b88f-471c36dfa7a0"
-version = "1.0.6+5"
-
-[[ChainRules]]
-deps = ["ChainRulesCore", "Compat", "LinearAlgebra", "Random", "Reexport", "Requires", "Statistics"]
-git-tree-sha1 = "e01f521443e3700f40ad3c7c1c6aa3a6940aaea1"
-uuid = "082447d4-558c-5d27-93f4-14fc19e9eca2"
-version = "0.7.54"
-
 [[ChainRulesCore]]
-deps = ["Compat", "LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "de4f08843c332d355852721adb1592bce7924da3"
+deps = ["Compat", "LinearAlgebra"]
+git-tree-sha1 = "12177ad6b3cad7fd50c8b3825ce24a99ad61c18f"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "0.9.29"
+version = "1.26.1"
+weakdeps = ["SparseArrays"]
 
-[[CodecBzip2]]
-deps = ["Bzip2_jll", "Libdl", "TranscodingStreams"]
-git-tree-sha1 = "2e62a725210ce3c3c2e1a3080190e7ca491f18d7"
-uuid = "523fee87-0ab8-5b00-afb7-3ecf72e48cfd"
-version = "0.7.2"
-
-[[CodecZlib]]
-deps = ["TranscodingStreams", "Zlib_jll"]
-git-tree-sha1 = "ded953804d019afa9a3f98981d99b33e3db7b6da"
-uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
-version = "0.7.0"
+    [ChainRulesCore.extensions]
+    ChainRulesCoreSparseArraysExt = "SparseArrays"
 
 [[CommonSubexpressions]]
-deps = ["MacroTools", "Test"]
-git-tree-sha1 = "7b8a93dba8af7e3b42fecabf646260105ac373f7"
+deps = ["MacroTools"]
+git-tree-sha1 = "cda2cfaebb4be89c9084adaca7dd7333369715c5"
 uuid = "bbf7d656-a473-5ed7-a52c-81e309532950"
-version = "0.3.0"
+version = "0.3.1"
 
 [[Compat]]
-deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "919c7f3151e79ff196add81d7f4e45d91bbf420b"
+deps = ["TOML", "UUIDs"]
+git-tree-sha1 = "9d8a54ce4b17aa5bdce0ea5c34bc5e7c340d16ad"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.25.0"
+version = "4.18.1"
+weakdeps = ["Dates", "LinearAlgebra"]
+
+    [Compat.extensions]
+    CompatLinearAlgebraExt = "LinearAlgebra"
 
 [[CompilerSupportLibraries_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "8e695f735fca77e9708e795eda62afdb869cbb70"
+deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "0.3.4+0"
+version = "1.1.1+0"
 
-[[DataStructures]]
-deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "4437b64df1e0adccc3e5d1adbc3ac741095e4677"
-uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.18.9"
+[[ConstructionBase]]
+git-tree-sha1 = "b4b092499347b18a015186eae3042f72267106cb"
+uuid = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
+version = "1.6.0"
+
+    [ConstructionBase.extensions]
+    ConstructionBaseIntervalSetsExt = "IntervalSets"
+    ConstructionBaseLinearAlgebraExt = "LinearAlgebra"
+    ConstructionBaseStaticArraysExt = "StaticArrays"
+
+    [ConstructionBase.weakdeps]
+    IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
+    LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [[Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
-[[DelimitedFiles]]
-deps = ["Mmap"]
-uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
-
 [[DiffResults]]
-deps = ["StaticArrays"]
-git-tree-sha1 = "c18e98cba888c6c25d1c3b048e4b3380ca956805"
+deps = ["StaticArraysCore"]
+git-tree-sha1 = "782dd5f4561f5d267313f23853baaaa4c52ea621"
 uuid = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"
-version = "1.0.3"
+version = "1.1.0"
 
 [[DiffRules]]
-deps = ["NaNMath", "Random", "SpecialFunctions"]
-git-tree-sha1 = "214c3fcac57755cfda163d91c58893a8723f93e9"
+deps = ["IrrationalConstants", "LogExpFunctions", "NaNMath", "Random", "SpecialFunctions"]
+git-tree-sha1 = "79a2aca180a85c690c58a020d47b426954b590f8"
 uuid = "b552c78f-8df3-52c6-915a-8e097449b14b"
-version = "1.0.2"
+version = "1.16.0"
 
-[[Distributed]]
-deps = ["Random", "Serialization", "Sockets"]
-uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+[[DifferentiationInterface]]
+deps = ["ADTypes", "LinearAlgebra"]
+git-tree-sha1 = "dbd46a5cd0e79a97438b0ebbec42e744e8f436fe"
+uuid = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
+version = "0.7.20"
+
+    [DifferentiationInterface.extensions]
+    DifferentiationInterfaceChainRulesCoreExt = "ChainRulesCore"
+    DifferentiationInterfaceDiffractorExt = "Diffractor"
+    DifferentiationInterfaceEnzymeExt = ["EnzymeCore", "Enzyme"]
+    DifferentiationInterfaceFastDifferentiationExt = "FastDifferentiation"
+    DifferentiationInterfaceFiniteDiffExt = "FiniteDiff"
+    DifferentiationInterfaceFiniteDifferencesExt = "FiniteDifferences"
+    DifferentiationInterfaceForwardDiffExt = ["ForwardDiff", "DiffResults"]
+    DifferentiationInterfaceGPUArraysCoreExt = ["GPUArraysCore", "Adapt"]
+    DifferentiationInterfaceGTPSAExt = "GTPSA"
+    DifferentiationInterfaceHyperHessiansExt = "HyperHessians"
+    DifferentiationInterfaceMooncakeExt = "Mooncake"
+    DifferentiationInterfacePolyesterForwardDiffExt = ["PolyesterForwardDiff", "ForwardDiff", "DiffResults"]
+    DifferentiationInterfaceReverseDiffExt = ["ReverseDiff", "DiffResults"]
+    DifferentiationInterfaceSparseArraysExt = "SparseArrays"
+    DifferentiationInterfaceSparseConnectivityTracerExt = "SparseConnectivityTracer"
+    DifferentiationInterfaceSparseMatrixColoringsExt = "SparseMatrixColorings"
+    DifferentiationInterfaceStaticArraysExt = "StaticArrays"
+    DifferentiationInterfaceSymbolicsExt = "Symbolics"
+    DifferentiationInterfaceTrackerExt = "Tracker"
+    DifferentiationInterfaceZygoteExt = ["Zygote", "ForwardDiff"]
+
+    [DifferentiationInterface.weakdeps]
+    Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    DiffResults = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"
+    Diffractor = "9f5e2b26-1114-432f-b630-d3fe2085c51c"
+    Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
+    EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
+    FastDifferentiation = "eb9bf01b-bf85-4b60-bf87-ee5de06c00be"
+    FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
+    FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
+    ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+    GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
+    GTPSA = "b27dd330-f138-47c5-815b-40db9dd9b6e8"
+    HyperHessians = "06b494a0-c8e0-40cc-ad32-d99506a00a6c"
+    Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
+    PolyesterForwardDiff = "98d1487c-24ca-40b6-b7ab-df2af84e126b"
+    ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+    SparseConnectivityTracer = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
+    SparseMatrixColorings = "0a514795-09f3-496d-8182-132a7b665d35"
+    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+    Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
+    Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
+    Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [[DocStringExtensions]]
-deps = ["LibGit2", "Markdown", "Pkg", "Test"]
-git-tree-sha1 = "50ddf44c53698f5e784bbebb3f4b21c5807401b1"
+deps = ["LibGit2"]
+git-tree-sha1 = "b19534d1895d702889b219c382a6e18010797f0b"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-version = "0.8.3"
+version = "0.8.6"
 
 [[Documenter]]
 deps = ["Base64", "Dates", "DocStringExtensions", "IOCapture", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
@@ -141,34 +207,56 @@ git-tree-sha1 = "3ebb967819b284dc1e3c0422229b58a40a255649"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 version = "0.26.3"
 
-[[FillArrays]]
-deps = ["LinearAlgebra", "Random", "SparseArrays"]
-git-tree-sha1 = "dd4ab4257c257532003eb9836eea07473fcc732e"
-uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.11.6"
+[[Downloads]]
+deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+version = "1.6.0"
+
+[[FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 
 [[FiniteDiff]]
-deps = ["ArrayInterface", "LinearAlgebra", "Requires", "SparseArrays", "StaticArrays"]
-git-tree-sha1 = "f6f80c8f934efd49a286bb5315360be66956dfc4"
+deps = ["ArrayInterface", "LinearAlgebra", "Setfield"]
+git-tree-sha1 = "07e98e3f332ee60179813dd9cdf21412e3c0a96a"
 uuid = "6a86dc24-6348-571c-b903-95158fe2bd41"
-version = "2.8.0"
+version = "2.32.0"
+
+    [FiniteDiff.extensions]
+    FiniteDiffBandedMatricesExt = "BandedMatrices"
+    FiniteDiffBlockBandedMatricesExt = "BlockBandedMatrices"
+    FiniteDiffSparseArraysExt = "SparseArrays"
+    FiniteDiffStaticArraysExt = "StaticArrays"
+
+    [FiniteDiff.weakdeps]
+    BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
+    BlockBandedMatrices = "ffab5731-97b5-5995-9138-79e8c1846df0"
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [[ForwardDiff]]
-deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "NaNMath", "Random", "SpecialFunctions", "StaticArrays"]
-git-tree-sha1 = "c68fb7481b71519d313114dca639b35262ff105f"
+deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "LinearAlgebra", "LogExpFunctions", "NaNMath", "Preferences", "Printf", "Random", "SpecialFunctions"]
+git-tree-sha1 = "244d838cae8f4f40bd7b0478a4912e265c50857d"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "0.10.17"
+version = "1.4.2"
+weakdeps = ["StaticArrays"]
+
+    [ForwardDiff.extensions]
+    ForwardDiffStaticArraysExt = "StaticArrays"
 
 [[FunctionWrappers]]
-git-tree-sha1 = "241552bc2209f0fa068b6415b1942cc0aa486bcc"
+git-tree-sha1 = "d62485945ce5ae9c0c48f124a84998d755bae00e"
 uuid = "069b7b12-0de2-55c6-9aab-29f3d0a68a2e"
-version = "1.1.2"
+version = "1.1.3"
 
-[[HTTP]]
-deps = ["Base64", "Dates", "IniFile", "MbedTLS", "NetworkOptions", "Sockets", "URIs"]
-git-tree-sha1 = "c9f380c76d8aaa1fa7ea9cf97bddbc0d5b15adc2"
-uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-version = "0.9.5"
+[[Future]]
+deps = ["Random"]
+uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
+
+[[Hwloc_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "XML2_jll", "Xorg_libpciaccess_jll"]
+git-tree-sha1 = "c35847ca5b4997fc8418836354a56c459bcf48d8"
+uuid = "e33a78d0-f292-5ffc-b300-72abe9b543c8"
+version = "2.14.0+0"
 
 [[IOCapture]]
 deps = ["Logging"]
@@ -176,273 +264,317 @@ git-tree-sha1 = "377252859f740c217b936cebcd918a44f9b53b59"
 uuid = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
 version = "0.1.1"
 
-[[IRTools]]
-deps = ["InteractiveUtils", "MacroTools", "Test"]
-git-tree-sha1 = "c67e7515a11f726f44083e74f218d134396d6510"
-uuid = "7869d1d1-7146-5819-86e3-90919afe41df"
-version = "0.4.2"
-
-[[IfElse]]
-git-tree-sha1 = "28e837ff3e7a6c3cdb252ce49fb412c8eb3caeef"
-uuid = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"
-version = "0.1.0"
-
-[[Inflate]]
-git-tree-sha1 = "f5fc07d4e706b84f72d54eedcc1c13d92fb0871c"
-uuid = "d25df0c9-e2be-5dd7-82c8-3ad0b3e990b9"
-version = "0.1.2"
-
-[[IniFile]]
-deps = ["Test"]
-git-tree-sha1 = "098e4d2c533924c921f9f9847274f2ad89e018b8"
-uuid = "83e8ac13-25f8-5344-8a64-a9f2b223428f"
-version = "0.5.0"
-
 [[InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[Ipopt]]
-deps = ["BinaryProvider", "Ipopt_jll", "Libdl", "LinearAlgebra", "MathOptInterface", "MathProgBase"]
-git-tree-sha1 = "7c526d73eeacf6495e694e8309f3c89d4b5f8912"
+deps = ["Ipopt_jll", "LinearAlgebra", "OpenBLAS32_jll", "PrecompileTools"]
+git-tree-sha1 = "f8443766032a81e1f2cddfd4f624a5650067f0d0"
 uuid = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
-version = "0.6.5"
+version = "1.15.0"
+
+    [Ipopt.extensions]
+    IpoptMathOptInterfaceExt = "MathOptInterface"
+
+    [Ipopt.weakdeps]
+    MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 
 [[Ipopt_jll]]
-deps = ["ASL_jll", "Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "MUMPS_seq_jll", "OpenBLAS32_jll", "Pkg"]
-git-tree-sha1 = "610e03d6ff38a70c2a5eca351d83638309f4afb5"
+deps = ["ASL_jll", "Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "MUMPS_seq_jll", "SPRAL_jll", "libblastrampoline_jll"]
+git-tree-sha1 = "d58bb7f6393b8ec1f6fb39eb6c1a7a83b8f8b521"
 uuid = "9cc047cb-c261-5740-88fc-0cf96f7bdcc7"
-version = "3.13.4+0"
+version = "300.1400.1902+0"
+
+[[IrrationalConstants]]
+git-tree-sha1 = "b2d91fe939cae05960e760110b328288867b5758"
+uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
+version = "0.2.6"
 
 [[JLLWrappers]]
-git-tree-sha1 = "a431f5f2ca3f4feef3bd7a5e94b8b8d4f2f647a0"
+deps = ["Artifacts", "Preferences"]
+git-tree-sha1 = "7204148362dafe5fe6a273f855b8ccbe4df8173e"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-version = "1.2.0"
+version = "1.8.0"
 
 [[JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
-git-tree-sha1 = "81690084b6198a2e1da36fcfda16eeca9f9f24e4"
+git-tree-sha1 = "31e996f0a15c7b280ba9f76636b3ff9e2ae58c9a"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "0.21.1"
+version = "0.21.4"
 
-[[JSONSchema]]
-deps = ["HTTP", "JSON", "ZipFile"]
-git-tree-sha1 = "b84ab8139afde82c7c65ba2b792fe12e01dd7307"
-uuid = "7d188eb4-7ad8-530c-ae41-71a32a6d4692"
-version = "0.3.3"
+[[LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+version = "0.6.4"
+
+[[LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+version = "8.4.0+0"
 
 [[LibGit2]]
-deps = ["Printf"]
+deps = ["Base64", "LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[LibGit2_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll"]
+uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
+version = "1.6.4+0"
+
+[[LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+version = "1.11.0+1"
 
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
-[[LightGraphs]]
-deps = ["ArnoldiMethod", "DataStructures", "Distributed", "Inflate", "LinearAlgebra", "Random", "SharedArrays", "SimpleTraits", "SparseArrays", "Statistics"]
-git-tree-sha1 = "432428df5f360964040ed60418dd5601ecd240b6"
-uuid = "093fc24a-ae57-5d10-9952-331d41423f4d"
-version = "1.3.5"
+[[Libiconv_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "be484f5c92fad0bd8acfef35fe017900b0b73809"
+uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
+version = "1.18.0+0"
 
 [[LinearAlgebra]]
-deps = ["Libdl"]
+deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[LogExpFunctions]]
+deps = ["DocStringExtensions", "IrrationalConstants", "LinearAlgebra"]
+git-tree-sha1 = "bba2d9aa057d8f126415de240573e86a8f39d2a1"
+uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
+version = "1.0.1"
+
+    [LogExpFunctions.extensions]
+    LogExpFunctionsChainRulesCoreExt = "ChainRulesCore"
+    LogExpFunctionsChangesOfVariablesExt = "ChangesOfVariables"
+    LogExpFunctionsInverseFunctionsExt = "InverseFunctions"
+
+    [LogExpFunctions.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    ChangesOfVariables = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
+    InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
 
 [[Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [[METIS_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "2dc1a9fc87e57e32b1fc186db78811157b30c118"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "2eefa8baa858871ae7770c98c3c2a7e46daba5b4"
 uuid = "d00139f3-1899-568f-a2f0-47f597d42d70"
-version = "5.1.0+5"
+version = "5.1.3+0"
 
 [[MUMPS_seq_jll]]
-deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "METIS_jll", "OpenBLAS32_jll", "Pkg"]
-git-tree-sha1 = "1a11a84b2af5feb5a62a820574804056cdc59c39"
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "METIS_jll", "libblastrampoline_jll"]
+git-tree-sha1 = "eb4f9c84cbe9139594752e3e5b71b2ed4be140b8"
 uuid = "d7ed1dd3-d0ae-5e8e-bfb4-87a502085b8d"
-version = "5.2.1+4"
+version = "500.900.0+0"
 
 [[MacroTools]]
-deps = ["Markdown", "Random"]
-git-tree-sha1 = "6a8a2a625ab0dea913aba95c11370589e0239ff0"
+git-tree-sha1 = "1e0228a030642014fe5cfe68c2c0a818f9e3f522"
 uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
-version = "0.5.6"
+version = "0.5.16"
 
 [[Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
-[[MathOptInterface]]
-deps = ["BenchmarkTools", "CodecBzip2", "CodecZlib", "JSON", "JSONSchema", "LinearAlgebra", "MutableArithmetics", "OrderedCollections", "SparseArrays", "Test", "Unicode"]
-git-tree-sha1 = "606efe4246da5407d7505265a1ead72467528996"
-uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-version = "0.9.20"
-
-[[MathProgBase]]
-deps = ["LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "9abbe463a1e9fc507f12a69e7f29346c2cdc472c"
-uuid = "fdba3010-5040-5b88-9595-932c9decdf73"
-version = "0.7.8"
-
-[[MbedTLS]]
-deps = ["Dates", "MbedTLS_jll", "Random", "Sockets"]
-git-tree-sha1 = "1c38e51c3d08ef2278062ebceade0e46cefc96fe"
-uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
-version = "1.0.3"
-
 [[MbedTLS_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "0eef589dd1c26a3ac9d753fe1a8bcad63f956fa6"
+deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.16.8+1"
+version = "2.28.1010+0"
 
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
-[[MutableArithmetics]]
-deps = ["LinearAlgebra", "SparseArrays", "Test"]
-git-tree-sha1 = "6b6bb8f550dc38310afd4a0af0786dc3222459e2"
-uuid = "d8a4904e-b15c-11e9-3269-09a3773c0cb0"
-version = "0.2.14"
+[[MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+version = "2025.12.2"
 
 [[NaNMath]]
-git-tree-sha1 = "bfe47e760d60b82b66b61d2d44128b62e3a369fb"
+deps = ["OpenLibm_jll"]
+git-tree-sha1 = "dbd2e8cd2c1c27f0b584f6661b4309609c5a685e"
 uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
-version = "0.3.5"
+version = "1.1.4"
 
 [[NetworkOptions]]
-git-tree-sha1 = "ed3157f48a05543cce9b241e1f2815f7e843d96e"
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 version = "1.2.0"
 
 [[OpenBLAS32_jll]]
-deps = ["CompilerSupportLibraries_jll", "Libdl", "Pkg"]
-git-tree-sha1 = "793b33911239d2651c356c823492b58d6490d36a"
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "6065c4cff8fee6c6770b277af45d5082baacdba1"
 uuid = "656ef2d0-ae68-5445-9ca0-591084a874a2"
-version = "0.3.9+4"
+version = "0.3.24+0"
+
+[[OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+version = "0.3.23+5"
+
+[[OpenLibm_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
+version = "0.8.5+0"
 
 [[OpenSpecFun_jll]]
-deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "9db77584158d0ab52307f8c04f8e7c08ca76b5b3"
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "1346c9208249809840c91b26703912dff463d335"
 uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
-version = "0.5.3+4"
-
-[[OrderedCollections]]
-git-tree-sha1 = "4fa2ba51070ec13fcc7517db714445b4ab986bdf"
-uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.4.0"
+version = "0.5.6+0"
 
 [[Parsers]]
-deps = ["Dates"]
-git-tree-sha1 = "223a825cccef2228f3fdbf2ecc7ca93363059073"
+deps = ["Dates", "PrecompileTools", "UUIDs"]
+git-tree-sha1 = "32a4e09c5f29402573d673901778a0e03b0807b9"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "1.0.16"
+version = "2.8.6"
 
 [[Pkg]]
-deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+version = "1.10.0"
+
+[[PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "5aa36f7049a63a1528fe8f7c3f2113413ffd4e1f"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.2.1"
+
+[[Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "8b770b60760d4451834fe79dd483e318eee709c4"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.5.2"
 
 [[Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [[REPL]]
-deps = ["InteractiveUtils", "Markdown", "Sockets"]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[Random]]
-deps = ["Serialization"]
+deps = ["SHA"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-
-[[Reexport]]
-git-tree-sha1 = "57d8440b0c7d98fc4f889e478e80f268d534c9d5"
-uuid = "189a3867-3050-52da-a836-e630ba90ab69"
-version = "1.0.0"
 
 [[Requires]]
 deps = ["UUIDs"]
-git-tree-sha1 = "4036a3bd08ac7e968e27c203d45f5fff15020621"
+git-tree-sha1 = "62389eeff14780bfe55195b7204c0d8738436d64"
 uuid = "ae029012-a4dd-5104-9daa-d747884805df"
-version = "1.1.3"
+version = "1.3.1"
 
 [[ReverseDiff]]
-deps = ["DiffResults", "DiffRules", "ForwardDiff", "FunctionWrappers", "LinearAlgebra", "MacroTools", "NaNMath", "Random", "SpecialFunctions", "StaticArrays", "Statistics"]
-git-tree-sha1 = "a4a45bcdc393c560fc13839dc1d19f3063fcb3b9"
+deps = ["ChainRulesCore", "DiffResults", "DiffRules", "ForwardDiff", "FunctionWrappers", "LinearAlgebra", "LogExpFunctions", "MacroTools", "NaNMath", "Random", "SpecialFunctions", "StaticArrays", "Statistics"]
+git-tree-sha1 = "f5f3c09103951beae390666a18e084655996370b"
 uuid = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
-version = "1.7.0"
+version = "1.17.0"
 
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
 
 [[SNOW]]
-deps = ["DiffResults", "FiniteDiff", "ForwardDiff", "Ipopt", "Requires", "ReverseDiff", "SparseArrays", "SparseDiffTools", "Zygote"]
+deps = ["DiffResults", "DifferentiationInterface", "FiniteDiff", "ForwardDiff", "Ipopt", "Requires", "ReverseDiff", "SparseArrays", "SparseMatrixColorings"]
 path = ".."
 uuid = "105f6ee8-0889-46b1-9d4b-65e03cbc8f13"
-version = "0.2.0"
+version = "1.0.0"
+
+[[SPRAL_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Hwloc_jll", "JLLWrappers", "Libdl", "METIS_jll", "libblastrampoline_jll"]
+git-tree-sha1 = "139fa63f03a16b3d859d925ee9149dfc15f21ece"
+uuid = "319450e9-13b8-58e8-aa9f-8fd1420848ab"
+version = "2025.9.18+0"
 
 [[Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
-[[SharedArrays]]
-deps = ["Distributed", "Mmap", "Random", "Serialization"]
-uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
-
-[[SimpleTraits]]
-deps = ["InteractiveUtils", "MacroTools"]
-git-tree-sha1 = "daf7aec3fe3acb2131388f93a4c409b8c7f62226"
-uuid = "699a6c99-e7fa-54fc-8d76-47d257e15c1d"
-version = "0.9.3"
+[[Setfield]]
+deps = ["ConstructionBase", "Future", "MacroTools", "StaticArraysCore"]
+git-tree-sha1 = "c5391c6ace3bc430ca630251d02ea9687169ca68"
+uuid = "efcf1570-3423-57d1-acb7-fd33fddbac46"
+version = "1.1.2"
 
 [[Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [[SparseArrays]]
-deps = ["LinearAlgebra", "Random"]
+deps = ["Libdl", "LinearAlgebra", "Random", "Serialization", "SuiteSparse_jll"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+version = "1.10.0"
 
-[[SparseDiffTools]]
-deps = ["Adapt", "ArrayInterface", "Compat", "DataStructures", "FiniteDiff", "ForwardDiff", "LightGraphs", "LinearAlgebra", "Requires", "SparseArrays", "VertexSafeGraphs"]
-git-tree-sha1 = "d05bc362e3fa1b0e2361594a706fc63ffbd140f3"
-uuid = "47a9eef4-7e08-11e9-0b38-333d64bd3804"
-version = "1.13.0"
+[[SparseMatrixColorings]]
+deps = ["ADTypes", "DocStringExtensions", "LinearAlgebra", "PrecompileTools", "Random", "SparseArrays"]
+git-tree-sha1 = "f63d76c7b7c329cf11badd564fd8ba877b09c3fe"
+uuid = "0a514795-09f3-496d-8182-132a7b665d35"
+version = "0.4.27"
+
+    [SparseMatrixColorings.extensions]
+    SparseMatrixColoringsCUDAExt = ["CUDA", "cuSPARSE"]
+    SparseMatrixColoringsCliqueTreesExt = "CliqueTrees"
+    SparseMatrixColoringsColorsExt = "Colors"
+    SparseMatrixColoringsGPUArraysExt = "GPUArrays"
+    SparseMatrixColoringsJuMPExt = ["JuMP", "MathOptInterface"]
+
+    [SparseMatrixColorings.weakdeps]
+    CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+    CliqueTrees = "60701a23-6482-424a-84db-faee86b9b1f8"
+    Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
+    GPUArrays = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
+    JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
+    MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
+    cuSPARSE = "b26da814-b3bc-49ef-b0ee-c816305aa060"
 
 [[SpecialFunctions]]
-deps = ["ChainRulesCore", "OpenSpecFun_jll"]
-git-tree-sha1 = "5919936c0e92cff40e57d0ddf0ceb667d42e5902"
+deps = ["IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
+git-tree-sha1 = "6547cbdd8ce32efba0d21c5a40fa96d1a3548f9f"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "1.3.0"
+version = "2.8.0"
+weakdeps = ["ChainRulesCore"]
 
-[[Static]]
-deps = ["IfElse"]
-git-tree-sha1 = "ddec5466a1d2d7e58adf9a427ba69763661aacf6"
-uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
-version = "0.2.4"
+    [SpecialFunctions.extensions]
+    SpecialFunctionsChainRulesCoreExt = "ChainRulesCore"
 
 [[StaticArrays]]
-deps = ["LinearAlgebra", "Random", "Statistics"]
-git-tree-sha1 = "9da72ed50e94dbff92036da395275ed114e04d49"
+deps = ["LinearAlgebra", "PrecompileTools", "Random", "StaticArraysCore"]
+git-tree-sha1 = "246a8bb2e6667f832eea063c3a56aef96429a3db"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.0.1"
+version = "1.9.18"
+weakdeps = ["ChainRulesCore", "Statistics"]
+
+    [StaticArrays.extensions]
+    StaticArraysChainRulesCoreExt = "ChainRulesCore"
+    StaticArraysStatisticsExt = "Statistics"
+
+[[StaticArraysCore]]
+git-tree-sha1 = "6ab403037779dae8c514bad259f32a447262455a"
+uuid = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+version = "1.4.4"
 
 [[Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+version = "1.10.0"
+
+[[SuiteSparse_jll]]
+deps = ["Artifacts", "Libdl", "libblastrampoline_jll"]
+uuid = "bea87d4a-7f5b-5778-9afe-8cc45184846c"
+version = "7.2.1+1"
+
+[[TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
+
+[[Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+version = "1.10.0"
 
 [[Test]]
-deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[[TranscodingStreams]]
-deps = ["Random", "Test"]
-git-tree-sha1 = "7c53c35547de1c5b9d46a4797cf6d8253807108c"
-uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
-version = "0.9.5"
-
-[[URIs]]
-git-tree-sha1 = "7855809b88d7b16e9b029afd17880930626f54a2"
-uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
-version = "1.2.0"
 
 [[UUIDs]]
 deps = ["Random", "SHA"]
@@ -451,32 +583,34 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
-[[VertexSafeGraphs]]
-deps = ["LightGraphs"]
-git-tree-sha1 = "b9b450c99a3ca1cc1c6836f560d8d887bcbe356e"
-uuid = "19fa3120-7c27-5ec5-8db8-b0b0aa330d6f"
-version = "0.1.2"
+[[XML2_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Libiconv_jll", "Zlib_jll"]
+git-tree-sha1 = "80d3930c6347cfce7ccf96bd3bafdf079d9c0390"
+uuid = "02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"
+version = "2.13.9+0"
 
-[[ZipFile]]
-deps = ["Libdl", "Printf", "Zlib_jll"]
-git-tree-sha1 = "c3a5637e27e914a7a445b8d0ad063d701931e9f7"
-uuid = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
-version = "0.9.3"
+[[Xorg_libpciaccess_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Zlib_jll"]
+git-tree-sha1 = "58972370b81423fc546c56a60ed1a009450177c3"
+uuid = "a65dc6b1-eb27-53a1-bb3e-dea574b5389e"
+version = "0.19.0+0"
 
 [[Zlib_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "320228915c8debb12cb434c59057290f0834dbf6"
+deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-version = "1.2.11+18"
+version = "1.2.13+1"
 
-[[Zygote]]
-deps = ["AbstractFFTs", "ChainRules", "DiffRules", "Distributed", "FillArrays", "ForwardDiff", "IRTools", "InteractiveUtils", "LinearAlgebra", "MacroTools", "NaNMath", "Random", "Requires", "SpecialFunctions", "Statistics", "ZygoteRules"]
-git-tree-sha1 = "52835a83f7c899cfcb95f796d584201812887ea8"
-uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
-version = "0.6.3"
+[[libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
+version = "5.11.0+0"
 
-[[ZygoteRules]]
-deps = ["MacroTools"]
-git-tree-sha1 = "9e7a1e8ca60b742e508a315c17eef5211e7fbfd7"
-uuid = "700de1a5-db45-46bc-99cf-38207098b444"
-version = "0.2.1"
+[[nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+version = "1.52.0+1"
+
+[[p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
+version = "17.6.1+0"

--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -136,9 +136,52 @@ options = Options(sparsity=sp, derivatives=[ReverseAD(), ForwardAD()])  # revers
 nothing #hide
 ```
 
-The coloring algorithm can be selected with `coloring_algorithm` from SparseMatrixColorings, for example `Options(sparsity=sp, derivatives=[ReverseAD(), ForwardAD()], coloring_algorithm=SparseMatrixColorings.GreedyColoringAlgorithm(SparseMatrixColorings.SmallestLast()))`.
-
 Currently supported options are ReverseAD, or RevZyg for the gradient, and ForwardAD or FD for the Jacobian.
+
+### Coloring algorithm
+
+Sparse Jacobians are computed using graph coloring: columns (or rows) that don't share any nonzero entries are grouped into the same "color" and perturbed together, so the number of function calls per Jacobian evaluation equals the number of colors rather than the number of design variables. Fewer colors means faster evaluations, but finding the minimum possible number of colors is itself an expensive combinatorial problem, so in practice a greedy heuristic is used, and different heuristics trade off coloring quality against the one-time cost of computing the coloring when the cache is built.
+
+`Options`, `createcache`, and `sparsejacobiancache` all accept a `coloring_algorithm` keyword to control this trade-off. It accepts any `ADTypes.AbstractColoringAlgorithm`, most conveniently one of the `SparseMatrixColorings.GreedyColoringAlgorithm` variants ([SparseMatrixColorings.jl docs](https://gdalle.github.io/SparseMatrixColorings.jl/stable/)). SNOW exports two ready-made choices:
+
+- `DEFAULT_COLORING_ALGORITHM` (the default if you don't specify anything): natural column order. Cheapest possible coloring construction cost.
+- `BEST_OF_COLORING_ALGORITHM`: tries the natural order, smallest-last, dynamic-largest-first, and incidence-degree orderings, keeping whichever produces fewer colors. Never worse than the default, sometimes meaningfully better (e.g. ~20% fewer colors on some real-world sparsity patterns), at a several-times-higher one-time construction cost - usually worthwhile unless your optimization only runs for a handful of iterations. Note this is still just the best of these four heuristics, not a guaranteed globally-minimal coloring (that's an NP-hard problem) - other orderings not included here could still occasionally do better on a given sparsity pattern.
+
+```@example sp
+options = Options(sparsity=sp, derivatives=[ReverseAD(), ForwardAD()], coloring_algorithm=BEST_OF_COLORING_ALGORITHM)
+nothing #hide
+```
+
+You can also build your own `GreedyColoringAlgorithm` from any ordering in SparseMatrixColorings.jl, or a tuple of several orderings (in which case the best of all of them is kept, at the combined cost of trying each):
+
+```@example sp
+using SparseMatrixColorings
+
+# a single specific ordering
+alg1 = SparseMatrixColorings.GreedyColoringAlgorithm(SparseMatrixColorings.SmallestLast())
+
+# largest-first (often competitive with smallest-last, sometimes better or worse depending on structure)
+alg2 = SparseMatrixColorings.GreedyColoringAlgorithm(SparseMatrixColorings.DynamicLargestFirst())
+
+# incidence-degree ordering
+alg3 = SparseMatrixColorings.GreedyColoringAlgorithm(SparseMatrixColorings.IncidenceDegree())
+
+# try several orderings and keep whichever gives the fewest colors (this is how
+# BEST_OF_COLORING_ALGORITHM itself is defined)
+alg4 = SparseMatrixColorings.GreedyColoringAlgorithm((
+    SparseMatrixColorings.NaturalOrder(),
+    SparseMatrixColorings.SmallestLast(),
+    SparseMatrixColorings.DynamicLargestFirst(),
+    SparseMatrixColorings.IncidenceDegree(),
+))
+
+options = Options(sparsity=sp, derivatives=[ReverseAD(), ForwardAD()], coloring_algorithm=alg1)
+nothing #hide
+```
+
+There's no single ordering that's always best - it depends on the sparsity structure of your problem. If cache construction time isn't a concern (it's a one-time cost, paid once per problem rather than once per Jacobian evaluation), trying a tuple of several orderings like `alg4` above is a reasonable way to get a good coloring without having to guess which heuristic suits your specific problem.
+
+You can also supply your own precomputed coloring via `SparseMatrixColorings.ConstantColoringAlgorithm`, which is any `ADTypes.AbstractColoringAlgorithm` too - useful if you already know a good coloring for your problem's sparsity pattern and want to skip the one-time coloring computation entirely.
 
 You can also provide your own derivatives.  For sparse Jacobians there are a wide variety of possible use cases (structure you can take advantage of, mixed-mode AD, using a combination of analytic and AD, etc.), and so for best performance you may want to provide your own.
 ```@example sp

--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -181,7 +181,30 @@ nothing #hide
 
 There's no single ordering that's always best - it depends on the sparsity structure of your problem. If cache construction time isn't a concern (it's a one-time cost, paid once per problem rather than once per Jacobian evaluation), trying a tuple of several orderings like `alg4` above is a reasonable way to get a good coloring without having to guess which heuristic suits your specific problem.
 
-You can also supply your own precomputed coloring via `SparseMatrixColorings.ConstantColoringAlgorithm`, which is any `ADTypes.AbstractColoringAlgorithm` too - useful if you already know a good coloring for your problem's sparsity pattern and want to skip the one-time coloring computation entirely.
+You can also supply your own precomputed coloring via `SparseMatrixColorings.ConstantColoringAlgorithm`, which is any `ADTypes.AbstractColoringAlgorithm` too. Unlike the algorithms above, it isn't really a coloring *algorithm* - it just returns whatever color vector you hand it, verbatim, skipping the one-time coloring computation entirely:
+
+```@example sp
+using SparseArrays
+
+nx = length(lx)
+Jsp = sparse(sp.rows, sp.cols, ones(length(sp.rows)), ng, nx)
+
+# a coloring you already know is valid for this sparsity pattern - e.g.
+# computed once and reused, or obvious from problem structure (banded,
+# block-diagonal, etc.). Here we just compute one with a real algorithm
+# to keep the example itself correct.
+known_good_coloring = SparseMatrixColorings.column_colors(SparseMatrixColorings.coloring(
+    Jsp,
+    SparseMatrixColorings.ColoringProblem(; structure=:nonsymmetric, partition=:column),
+    SparseMatrixColorings.GreedyColoringAlgorithm(),
+))
+constalg = SparseMatrixColorings.ConstantColoringAlgorithm(Jsp, known_good_coloring)
+
+options = Options(sparsity=sp, derivatives=[ReverseAD(), ForwardAD(coloring_algorithm=constalg)])
+nothing #hide
+```
+
+**Use this with caution.** `ConstantColoringAlgorithm` does not verify that the coloring you provide is actually valid for the given sparsity pattern - per its own documentation, "this is the responsibility of the user." If two columns sharing a color also share a nonzero row, `sparsejacobian!` will silently compute a **wrong Jacobian**, with no error or warning. It's also static: if your sparsity pattern ever changes (different problem size, different `SparsePattern`), a stale color vector won't adapt - you'd need to recompute and supply a new one yourself. Only reach for this if you can guarantee the coloring is correct for your exact sparsity pattern, and it isn't going to change out from under you.
 
 You can also provide your own derivatives.  For sparse Jacobians there are a wide variety of possible use cases (structure you can take advantage of, mixed-mode AD, using a combination of analytic and AD, etc.), and so for best performance you may want to provide your own.
 ```@example sp

--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -142,13 +142,13 @@ Currently supported options are ReverseAD, or RevZyg for the gradient, and Forwa
 
 Sparse Jacobians are computed using graph coloring: columns (or rows) that don't share any nonzero entries are grouped into the same "color" and perturbed together, so the number of function calls per Jacobian evaluation equals the number of colors rather than the number of design variables. Fewer colors means faster evaluations, but finding the minimum possible number of colors is itself an expensive combinatorial problem, so in practice a greedy heuristic is used, and different heuristics trade off coloring quality against the one-time cost of computing the coloring when the cache is built.
 
-`Options`, `createcache`, and `sparsejacobiancache` all accept a `coloring_algorithm` keyword to control this trade-off. It accepts any `ADTypes.AbstractColoringAlgorithm`, most conveniently one of the `SparseMatrixColorings.GreedyColoringAlgorithm` variants ([SparseMatrixColorings.jl docs](https://gdalle.github.io/SparseMatrixColorings.jl/stable/)). SNOW exports two ready-made choices:
+`ForwardAD`, `ForwardFD`, `CentralFD`, and `ComplexStep` all accept a `coloring_algorithm` keyword to control this trade-off. It accepts any `ADTypes.AbstractColoringAlgorithm`, most conveniently one of the `SparseMatrixColorings.GreedyColoringAlgorithm` variants ([SparseMatrixColorings.jl docs](https://gdalle.github.io/SparseMatrixColorings.jl/stable/)). SNOW exports two ready-made choices:
 
 - `DEFAULT_COLORING_ALGORITHM` (the default if you don't specify anything): natural column order. Cheapest possible coloring construction cost.
 - `BEST_OF_COLORING_ALGORITHM`: tries the natural order, smallest-last, dynamic-largest-first, and incidence-degree orderings, keeping whichever produces fewer colors. Never worse than the default, sometimes meaningfully better (e.g. ~20% fewer colors on some real-world sparsity patterns), at a several-times-higher one-time construction cost - usually worthwhile unless your optimization only runs for a handful of iterations. Note this is still just the best of these four heuristics, not a guaranteed globally-minimal coloring (that's an NP-hard problem) - other orderings not included here could still occasionally do better on a given sparsity pattern.
 
 ```@example sp
-options = Options(sparsity=sp, derivatives=[ReverseAD(), ForwardAD()], coloring_algorithm=BEST_OF_COLORING_ALGORITHM)
+options = Options(sparsity=sp, derivatives=[ReverseAD(), ForwardAD(coloring_algorithm=BEST_OF_COLORING_ALGORITHM)])
 nothing #hide
 ```
 
@@ -175,7 +175,7 @@ alg4 = SparseMatrixColorings.GreedyColoringAlgorithm((
     SparseMatrixColorings.IncidenceDegree(),
 ))
 
-options = Options(sparsity=sp, derivatives=[ReverseAD(), ForwardAD()], coloring_algorithm=alg1)
+options = Options(sparsity=sp, derivatives=[ReverseAD(), ForwardAD(coloring_algorithm=alg1)])
 nothing #hide
 ```
 

--- a/src/SNOW.jl
+++ b/src/SNOW.jl
@@ -16,6 +16,7 @@ include("derivatives.jl")
 
 export ForwardAD, ReverseAD, RevZyg, ForwardFD, CentralFD, ComplexStep, UserDeriv
 export DensePattern, SparsePattern
+export DEFAULT_COLORING_ALGORITHM, BEST_OF_COLORING_ALGORITHM
 
 include("interface.jl")
 

--- a/src/SNOW.jl
+++ b/src/SNOW.jl
@@ -1,5 +1,6 @@
 module SNOW
 
+using ADTypes
 using ForwardDiff
 using DifferentiationInterface
 using ReverseDiff

--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -5,15 +5,9 @@
 
 abstract type AbstractDiffMethod end
 
-struct ForwardAD <: AbstractDiffMethod end
 struct ReverseAD <: AbstractDiffMethod end
 # struct RevZyg <: AbstractDiffMethod end  # only used for gradients (not jacobians)
-struct ForwardFD <: AbstractDiffMethod end
-struct CentralFD <: AbstractDiffMethod end
-struct ComplexStep <: AbstractDiffMethod end
 struct UserDeriv <: AbstractDiffMethod end   # user-specified derivatives
-
-FD = Union{ForwardFD, CentralFD, ComplexStep}
 
 """
 Default coloring algorithm for sparse Jacobians: natural column order,
@@ -34,8 +28,8 @@ Coloring algorithm that tries the natural column order, smallest-last,
 dynamic-largest-first, and incidence-degree orderings, keeping whichever
 gives fewest colors. Fewer colors means fewer function calls per Jacobian
 evaluation, at the cost of a several-times-higher one-time cache
-construction cost. Pass to `coloring_algorithm` on `sparsejacobiancache`,
-`createcache`, or `Options` to opt in.
+construction cost. Pass to `coloring_algorithm` on
+`ForwardAD`/`ForwardFD`/`CentralFD`/`ComplexStep` to opt in.
 
 Note this is still just the best of these four heuristics, not a
 guaranteed globally-minimal coloring (that's an NP-hard problem) - other
@@ -48,6 +42,42 @@ const BEST_OF_COLORING_ALGORITHM = SparseMatrixColorings.GreedyColoringAlgorithm
     SparseMatrixColorings.DynamicLargestFirst(),
     SparseMatrixColorings.IncidenceDegree(),
 ))
+
+"""
+    ForwardAD(; coloring_algorithm=DEFAULT_COLORING_ALGORITHM)
+
+`coloring_algorithm` is only used for sparse Jacobians, and may be any
+`ADTypes.AbstractColoringAlgorithm` (e.g. from SparseMatrixColorings.jl).
+"""
+struct ForwardAD{TC<:ADTypes.AbstractColoringAlgorithm} <: AbstractDiffMethod
+    coloring_algorithm::TC
+end
+ForwardAD(; coloring_algorithm=DEFAULT_COLORING_ALGORITHM) = ForwardAD(coloring_algorithm)
+
+"""
+    ForwardFD(; coloring_algorithm=DEFAULT_COLORING_ALGORITHM)
+    CentralFD(; coloring_algorithm=DEFAULT_COLORING_ALGORITHM)
+    ComplexStep(; coloring_algorithm=DEFAULT_COLORING_ALGORITHM)
+
+`coloring_algorithm` is only used for sparse Jacobians, and may be any
+`ADTypes.AbstractColoringAlgorithm` (e.g. from SparseMatrixColorings.jl).
+"""
+struct ForwardFD{TC<:ADTypes.AbstractColoringAlgorithm} <: AbstractDiffMethod
+    coloring_algorithm::TC
+end
+ForwardFD(; coloring_algorithm=DEFAULT_COLORING_ALGORITHM) = ForwardFD(coloring_algorithm)
+
+struct CentralFD{TC<:ADTypes.AbstractColoringAlgorithm} <: AbstractDiffMethod
+    coloring_algorithm::TC
+end
+CentralFD(; coloring_algorithm=DEFAULT_COLORING_ALGORITHM) = CentralFD(coloring_algorithm)
+
+struct ComplexStep{TC<:ADTypes.AbstractColoringAlgorithm} <: AbstractDiffMethod
+    coloring_algorithm::TC
+end
+ComplexStep(; coloring_algorithm=DEFAULT_COLORING_ALGORITHM) = ComplexStep(coloring_algorithm)
+
+FD = Union{ForwardFD, CentralFD, ComplexStep}
 
 """
 convert to type used in FiniteDiff package
@@ -538,15 +568,14 @@ Cache for sparse jacobian using ForwardDiff
 - `nx::Int`: number of design variables
 - `ng::Int`: number of constraints
 """
-function sparsejacobiancache(sp::SparsePattern, dtype::ForwardAD, func!, nx, ng;
-    coloring_algorithm=DEFAULT_COLORING_ALGORITHM)
+function sparsejacobiancache(sp::SparsePattern, dtype::ForwardAD, func!, nx, ng)
 
     Jsp = sparse(sp.rows, sp.cols, ones(length(sp.rows)), ng, nx)
     Jwork = sparse(sp.rows, sp.cols, zeros(length(sp.rows)), ng, nx)
     backend = DifferentiationInterface.AutoSparse(
         DifferentiationInterface.AutoForwardDiff();
-        sparsity_detector = DifferentiationInterface.ADTypes.KnownJacobianSparsityDetector(Jsp),
-        coloring_algorithm = coloring_algorithm,
+        sparsity_detector = ADTypes.KnownJacobianSparsityDetector(Jsp),
+        coloring_algorithm = dtype.coloring_algorithm,
     )
     cache = (
         prep = DifferentiationInterface.prepare_jacobian(func!, zeros(ng), backend, zeros(nx)),
@@ -637,8 +666,7 @@ Cache for sparse jacobian using finite differencing
 - `nx::Int`: number of design variables
 - `ng::Int`: number of constraints
 """
-function sparsejacobiancache(sp::SparsePattern, dtype::FD, func!, nx, ng;
-    coloring_algorithm=DEFAULT_COLORING_ALGORITHM)
+function sparsejacobiancache(sp::SparsePattern, dtype::FD, func!, nx, ng)
 
     x = zeros(nx)
     Jwork = sparse(sp.rows, sp.cols, zeros(length(sp.rows)), ng, nx)
@@ -646,7 +674,7 @@ function sparsejacobiancache(sp::SparsePattern, dtype::FD, func!, nx, ng;
     colors = SparseMatrixColorings.column_colors(SparseMatrixColorings.coloring(
         Jwork,
         SparseMatrixColorings.ColoringProblem(; structure = :nonsymmetric, partition = :column),
-        coloring_algorithm,
+        dtype.coloring_algorithm,
     ))
     fcache = FiniteDiff.JacobianCache(x, zeros(ng), fdtype,
         colorvec=colors, sparsity=Jwork)
@@ -706,11 +734,9 @@ create cache for derivatives when the jacobian is sparse
 - `nx::Int`: number of design variables
 - `ng::Int`: number of constraints
 """
-function createcache(sp::SparsePattern, dtype::T, func!, nx, ng;
-    coloring_algorithm=DEFAULT_COLORING_ALGORITHM) where T<:Vector
+function createcache(sp::SparsePattern, dtype::T, func!, nx, ng) where T<:Vector
     gradcache = gradientcache(dtype[1], func!, nx, ng)
-    jaccache = sparsejacobiancache(sp, dtype[2], func!, nx, ng;
-        coloring_algorithm=coloring_algorithm)
+    jaccache = sparsejacobiancache(sp, dtype[2], func!, nx, ng)
 
     return SparseCache(gradcache, jaccache)
 end
@@ -748,8 +774,7 @@ Cache for sparse jacobian with user-supplied derivatives
 - `nx::Int`: number of design variables
 - `ng::Int`: number of constraints
 """
-function createcache(sp::SparsePattern, dtype::UserDeriv, func!, nx, ng;
-    coloring_algorithm=DEFAULT_COLORING_ALGORITHM)
+function createcache(sp::SparsePattern, dtype::UserDeriv, func!, nx, ng)
     return GradOrJacCache(func!, 0.0, nothing, dtype)
 end
 

--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -16,6 +16,40 @@ struct UserDeriv <: AbstractDiffMethod end   # user-specified derivatives
 FD = Union{ForwardFD, CentralFD, ComplexStep}
 
 """
+Default coloring algorithm for sparse Jacobians: natural column order,
+matching the cheapest one-time cache-construction cost.
+
+For an alternative that tries several orderings (keeping whichever gives
+fewer colors - never worse than natural order alone, sometimes meaningfully
+better, e.g. ~20% fewer colors on some real-world sparsity patterns, at a
+several-times-higher one-time cache construction cost), use
+[`BEST_OF_COLORING_ALGORITHM`](@ref).
+"""
+const DEFAULT_COLORING_ALGORITHM = SparseMatrixColorings.GreedyColoringAlgorithm(
+    SparseMatrixColorings.NaturalOrder(),
+)
+
+"""
+Coloring algorithm that tries the natural column order, smallest-last,
+dynamic-largest-first, and incidence-degree orderings, keeping whichever
+gives fewest colors. Fewer colors means fewer function calls per Jacobian
+evaluation, at the cost of a several-times-higher one-time cache
+construction cost. Pass to `coloring_algorithm` on `sparsejacobiancache`,
+`createcache`, or `Options` to opt in.
+
+Note this is still just the best of these four heuristics, not a
+guaranteed globally-minimal coloring (that's an NP-hard problem) - other
+orderings not included here could still occasionally do better on a given
+sparsity pattern.
+"""
+const BEST_OF_COLORING_ALGORITHM = SparseMatrixColorings.GreedyColoringAlgorithm((
+    SparseMatrixColorings.NaturalOrder(),
+    SparseMatrixColorings.SmallestLast(),
+    SparseMatrixColorings.DynamicLargestFirst(),
+    SparseMatrixColorings.IncidenceDegree(),
+))
+
+"""
 convert to type used in FiniteDiff package
 """
 function finitediff_type(dtype)
@@ -505,7 +539,7 @@ Cache for sparse jacobian using ForwardDiff
 - `ng::Int`: number of constraints
 """
 function sparsejacobiancache(sp::SparsePattern, dtype::ForwardAD, func!, nx, ng;
-    coloring_algorithm=SparseMatrixColorings.GreedyColoringAlgorithm())
+    coloring_algorithm=DEFAULT_COLORING_ALGORITHM)
 
     Jsp = sparse(sp.rows, sp.cols, ones(length(sp.rows)), ng, nx)
     Jwork = sparse(sp.rows, sp.cols, zeros(length(sp.rows)), ng, nx)
@@ -604,7 +638,7 @@ Cache for sparse jacobian using finite differencing
 - `ng::Int`: number of constraints
 """
 function sparsejacobiancache(sp::SparsePattern, dtype::FD, func!, nx, ng;
-    coloring_algorithm=SparseMatrixColorings.GreedyColoringAlgorithm())
+    coloring_algorithm=DEFAULT_COLORING_ALGORITHM)
 
     x = zeros(nx)
     Jwork = sparse(sp.rows, sp.cols, zeros(length(sp.rows)), ng, nx)
@@ -673,7 +707,7 @@ create cache for derivatives when the jacobian is sparse
 - `ng::Int`: number of constraints
 """
 function createcache(sp::SparsePattern, dtype::T, func!, nx, ng;
-    coloring_algorithm=SparseMatrixColorings.GreedyColoringAlgorithm()) where T<:Vector
+    coloring_algorithm=DEFAULT_COLORING_ALGORITHM) where T<:Vector
     gradcache = gradientcache(dtype[1], func!, nx, ng)
     jaccache = sparsejacobiancache(sp, dtype[2], func!, nx, ng;
         coloring_algorithm=coloring_algorithm)
@@ -715,7 +749,7 @@ Cache for sparse jacobian with user-supplied derivatives
 - `ng::Int`: number of constraints
 """
 function createcache(sp::SparsePattern, dtype::UserDeriv, func!, nx, ng;
-    coloring_algorithm=SparseMatrixColorings.GreedyColoringAlgorithm())
+    coloring_algorithm=DEFAULT_COLORING_ALGORITHM)
     return GradOrJacCache(func!, 0.0, nothing, dtype)
 end
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -9,33 +9,26 @@ function optimize(solver::AbstractSolver, cache, x0, lx, ux, lg, ug, rows, cols)
 end
 
 """
-    Options(;sparsity=DensePattern(), derivatives=ForwardFD(), solver=IPOPT(),
-        coloring_algorithm=DEFAULT_COLORING_ALGORITHM)
+    Options(;sparsity=DensePattern(), derivatives=ForwardFD(), solver=IPOPT())
 
 Options for SNOW.  Default is dense, forward finite differencing, and IPOPT.
 
 # Arguments
 - `sparsity::AbstractSparsityPattern`: specify sparsity pattern
 - `derivatives::AbstractDiffMethod`: specific differentiation methods to use
-    or `derivatives::Vector{AbstractDiffMethod}`: vector of length two, 
+    or `derivatives::Vector{AbstractDiffMethod}`: vector of length two,
     first for gradient differentiation method, second for jacobian differentiation method
 - `solver::AbstractSolver`: specificy which optimizer to use
-- `coloring_algorithm`: algorithm used for sparse Jacobian coloring
 """
-struct Options{T1,T2,T3,T4}
+struct Options{T1,T2,T3}
     sparsity::T1  # AbstractSparsityPattern
     derivatives::T2  # AbstractDiffMethod
     solver::T3  # AbstractSolver
-    coloring_algorithm::T4
 end
 
-Options(sparsity, derivatives, solver) =
-    Options(sparsity, derivatives, solver, SparseMatrixColorings.GreedyColoringAlgorithm())
-
 # defaults
-Options(; sparsity=DensePattern(), derivatives=ForwardFD(), solver=IPOPT(),
-    coloring_algorithm=DEFAULT_COLORING_ALGORITHM
-    ) = Options(sparsity, derivatives, solver, coloring_algorithm)
+Options(; sparsity=DensePattern(), derivatives=ForwardFD(), solver=IPOPT()
+    ) = Options(sparsity, derivatives, solver)
 
 
 # private convenience method to size bounds of length 1 to required length
@@ -71,12 +64,7 @@ function minimize(func!, x0, ng, lx=-Inf, ux=Inf, lg=-Inf, ug=0.0, options=Optio
     ug = resizebounds(ug, ng)
     
     # create cache
-    cache = if options.sparsity isa SparsePattern
-        createcache(options.sparsity, options.derivatives, func!, nx, ng;
-            coloring_algorithm=options.coloring_algorithm)
-    else
-        createcache(options.sparsity, options.derivatives, func!, nx, ng)
-    end
+    cache = createcache(options.sparsity, options.derivatives, func!, nx, ng)
 
     # determine sparsity pattern
     rows, cols = getsparsity(options.sparsity, nx, ng)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -10,7 +10,7 @@ end
 
 """
     Options(;sparsity=DensePattern(), derivatives=ForwardFD(), solver=IPOPT(),
-        coloring_algorithm=SparseMatrixColorings.GreedyColoringAlgorithm())
+        coloring_algorithm=DEFAULT_COLORING_ALGORITHM)
 
 Options for SNOW.  Default is dense, forward finite differencing, and IPOPT.
 
@@ -34,7 +34,7 @@ Options(sparsity, derivatives, solver) =
 
 # defaults
 Options(; sparsity=DensePattern(), derivatives=ForwardFD(), solver=IPOPT(),
-    coloring_algorithm=SparseMatrixColorings.GreedyColoringAlgorithm()
+    coloring_algorithm=DEFAULT_COLORING_ALGORITHM
     ) = Options(sparsity, derivatives, solver, coloring_algorithm)
 
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,3 +1,6 @@
 [deps]
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+SparseMatrixColorings = "0a514795-09f3-496d-8182-132a7b665d35"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -82,7 +82,12 @@ for algorithm in (
         SNOW.SparseMatrixColorings.SmallestLast()),
     SNOW.SparseMatrixColorings.ConstantColoringAlgorithm(ones(ng, nx), [1, 2]),
 )
-    for dtype in (ForwardAD(coloring_algorithm=algorithm), ForwardFD(coloring_algorithm=algorithm))
+    for dtype in (
+        ForwardAD(coloring_algorithm=algorithm),
+        ForwardFD(coloring_algorithm=algorithm),
+        CentralFD(coloring_algorithm=algorithm),
+        ComplexStep(coloring_algorithm=algorithm),
+    )
         dg = zeros(length(sp.rows))
         cache = SNOW.createcache(sp, [ReverseAD(), dtype], test1!, nx, ng)
         SNOW.evaluate!(g, df, dg, x, cache)
@@ -92,6 +97,53 @@ end
 
 @test ForwardAD().coloring_algorithm === SNOW.DEFAULT_COLORING_ALGORITHM
 @test ForwardFD().coloring_algorithm === SNOW.DEFAULT_COLORING_ALGORITHM
+@test CentralFD().coloring_algorithm === SNOW.DEFAULT_COLORING_ALGORITHM
+@test ComplexStep().coloring_algorithm === SNOW.DEFAULT_COLORING_ALGORITHM
+
+# user-supplied derivatives (no AD/FD at all) - dense and sparse
+function userderiv_dense!(g, df, Jac, x)
+    f = x[1]^2 - x[2]
+    g[1] = x[2] - 2*x[1]
+    g[2] = -x[2]
+    g[3] = x[1]^2
+    df[1] = 2*x[1]
+    df[2] = -1.0
+    Jac[1,1] = -2.0
+    Jac[1,2] = 1.0
+    Jac[2,1] = 0.0
+    Jac[2,2] = -1.0
+    Jac[3,1] = 2*x[1]
+    Jac[3,2] = 0.0
+    return f
+end
+
+dg = zeros(ng*nx)
+cache = SNOW.createcache(DensePattern(), UserDeriv(), userderiv_dense!, nx, ng)
+SNOW.evaluate!(g, df, dg, x, cache)
+@test df == [2*x[1]; -1.0]
+@test dg == [-2.0, 0.0, 2*x[1], 1.0, -1.0, 0.0]
+
+# user-supplied derivatives, sparse: dg is a vector in sp.rows/sp.cols order
+# (sp.rows == [1, 3, 1, 2], sp.cols == [1, 1, 2, 2])
+function userderiv_sparse!(g, df, dg, x)
+    f = x[1]^2 - x[2]
+    g[1] = x[2] - 2*x[1]
+    g[2] = -x[2]
+    g[3] = x[1]^2
+    df[1] = 2*x[1]
+    df[2] = -1.0
+    dg[1] = -2.0
+    dg[2] = 2*x[1]
+    dg[3] = 1.0
+    dg[4] = -1.0
+    return f
+end
+
+dg = zeros(length(sp.rows))
+cache = SNOW.createcache(sp, UserDeriv(), userderiv_sparse!, nx, ng)
+SNOW.evaluate!(g, df, dg, x, cache)
+@test df == [2*x[1]; -1.0]
+@test dg == [-2.0, 2*x[1], 1.0, -1.0]
 
 # # sparse with zygote and forward
 # dg = zeros(length(sp.rows))
@@ -214,13 +266,15 @@ SNOW.sparsejacobian!(dg, x, cache)
 Jsparse = Matrix(sparse(sp.rows, sp.cols, dg, ng, nx))
 @test isapprox(Jsparse, Jdense; atol=1e-8)
 
-dtypefd = ForwardFD(coloring_algorithm=BEST_OF_COLORING_ALGORITHM)
-@test dtypefd.coloring_algorithm === BEST_OF_COLORING_ALGORITHM
-cachefd = SNOW.sparsejacobiancache(sp, dtypefd, tridiagonal!, nx, ng)
-dgfd = zeros(length(sp.rows))
-SNOW.sparsejacobian!(dgfd, x, cachefd)
-Jsparsefd = Matrix(sparse(sp.rows, sp.cols, dgfd, ng, nx))
-@test isapprox(Jsparsefd, Jdense; atol=1e-4)
+for FDType in (ForwardFD, CentralFD, ComplexStep)
+    dtypefd = FDType(coloring_algorithm=BEST_OF_COLORING_ALGORITHM)
+    @test dtypefd.coloring_algorithm === BEST_OF_COLORING_ALGORITHM
+    cachefd = SNOW.sparsejacobiancache(sp, dtypefd, tridiagonal!, nx, ng)
+    dgfd = zeros(length(sp.rows))
+    SNOW.sparsejacobian!(dgfd, x, cachefd)
+    Jsparsefd = Matrix(sparse(sp.rows, sp.cols, dgfd, ng, nx))
+    @test isapprox(Jsparsefd, Jdense; atol=1e-4)
+end
 
 # a user-supplied precomputed coloring (not a GreedyColoringAlgorithm) should
 # also work, exercising the fully generic ADTypes.AbstractColoringAlgorithm path
@@ -234,12 +288,14 @@ SNOW.sparsejacobian!(dgconst, x, cacheconst)
 Jsparseconst = Matrix(sparse(sp.rows, sp.cols, dgconst, ng, nx))
 @test isapprox(Jsparseconst, Jdense; atol=1e-8)
 
-dtypefdconst = ForwardFD(coloring_algorithm=constalg)
-cachefdconst = SNOW.sparsejacobiancache(sp, dtypefdconst, tridiagonal!, nx, ng)
-dgfdconst = zeros(length(sp.rows))
-SNOW.sparsejacobian!(dgfdconst, x, cachefdconst)
-Jsparsefdconst = Matrix(sparse(sp.rows, sp.cols, dgfdconst, ng, nx))
-@test isapprox(Jsparsefdconst, Jdense; atol=1e-4)
+for FDType in (ForwardFD, CentralFD, ComplexStep)
+    dtypefdconst = FDType(coloring_algorithm=constalg)
+    cachefdconst = SNOW.sparsejacobiancache(sp, dtypefdconst, tridiagonal!, nx, ng)
+    dgfdconst = zeros(length(sp.rows))
+    SNOW.sparsejacobian!(dgfdconst, x, cachefdconst)
+    Jsparsefdconst = Matrix(sparse(sp.rows, sp.cols, dgfdconst, ng, nx))
+    @test isapprox(Jsparsefdconst, Jdense; atol=1e-4)
+end
 
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -235,11 +235,8 @@ Jsparse = Matrix(sparse(sp.rows, sp.cols, dg, ng, nx))
 end
 
 
-@testset "sparse jacobian - named coloring algorithm presets" begin
-
-# default is the cheap natural-order coloring; users can opt into
-# BEST_OF_COLORING_ALGORITHM (or any other ADTypes.AbstractColoringAlgorithm)
-# for potentially fewer colors at a higher one-time cache-construction cost
+# shared by the "named coloring algorithm presets" and "repeated evaluation"
+# testsets below
 function tridiagonal!(g, x)
     n = length(x)
     g[1] = x[1]^2 - 2*x[2]
@@ -249,6 +246,12 @@ function tridiagonal!(g, x)
     g[n] = x[n]^2 - x[n-1]
     return sum(abs2, x)
 end
+
+@testset "sparse jacobian - named coloring algorithm presets" begin
+
+# default is the cheap natural-order coloring; users can opt into
+# BEST_OF_COLORING_ALGORITHM (or any other ADTypes.AbstractColoringAlgorithm)
+# for potentially fewer colors at a higher one-time cache-construction cost
 
 nx = 10
 ng = 10
@@ -347,15 +350,6 @@ end
 # a single cache must produce correct results across many calls at
 # different x, not just the first call (catches stale-state bugs in
 # reused scratch buffers / prepared coloring state)
-function tridiagonal!(g, x)
-    n = length(x)
-    g[1] = x[1]^2 - 2*x[2]
-    for i in 2:n-1
-        g[i] = x[i-1]*x[i] - x[i+1]^2 + sin(x[i])
-    end
-    g[n] = x[n]^2 - x[n-1]
-    return sum(abs2, x)
-end
 
 nx = 10
 ng = 10
@@ -471,6 +465,19 @@ ng = 3
 options = Options(solver=IPOPT(), derivatives=ForwardFD())
 xopt, fopt, info, out = minimize(barnes, x0, ng, lx, ux, -Inf, 0.0, options)
 
+
+@test isapprox(xopt[1], 49.5263; atol=1e-4)
+@test isapprox(xopt[2], 19.6228; atol=1e-4)
+@test isapprox(fopt, -31.6368; atol=1e-4)
+@test info == :Solve_Succeeded || info == :Solved_To_Acceptable_Level
+
+# same problem, but through a SparsePattern + DifferentiationInterface-based
+# ForwardAD sparse jacobian, end-to-end through the real Ipopt callback loop
+# (Ipopt calls the jacobian callback many times at different x during the
+# solve, unlike the isolated single/few-call tests in the testsets above)
+sp_barnes = SparsePattern(ForwardAD(), barnes, ng, lx, ux)
+options = Options(solver=IPOPT(), derivatives=[ReverseAD(), ForwardAD()], sparsity=sp_barnes)
+xopt, fopt, info, out = minimize(barnes, x0, ng, lx, ux, -Inf, 0.0, options)
 
 @test isapprox(xopt[1], 49.5263; atol=1e-4)
 @test isapprox(xopt[2], 19.6228; atol=1e-4)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -82,19 +82,16 @@ for algorithm in (
         SNOW.SparseMatrixColorings.SmallestLast()),
     SNOW.SparseMatrixColorings.ConstantColoringAlgorithm(ones(ng, nx), [1, 2]),
 )
-    for dtype in (ForwardAD(), ForwardFD())
+    for dtype in (ForwardAD(coloring_algorithm=algorithm), ForwardFD(coloring_algorithm=algorithm))
         dg = zeros(length(sp.rows))
-        cache = SNOW.createcache(sp, [ReverseAD(), dtype], test1!, nx, ng;
-            coloring_algorithm=algorithm)
+        cache = SNOW.createcache(sp, [ReverseAD(), dtype], test1!, nx, ng)
         SNOW.evaluate!(g, df, dg, x, cache)
         @test isapprox(dg, [-2.0, 2*x[1], 1.0, -1.0])
     end
 end
 
-options = Options(sparsity=sp, derivatives=[ReverseAD(), ForwardAD()],
-    coloring_algorithm=SNOW.SparseMatrixColorings.GreedyColoringAlgorithm(
-        SNOW.SparseMatrixColorings.SmallestLast()))
-@test options.coloring_algorithm isa SNOW.SparseMatrixColorings.GreedyColoringAlgorithm
+@test ForwardAD().coloring_algorithm === SNOW.DEFAULT_COLORING_ALGORITHM
+@test ForwardFD().coloring_algorithm === SNOW.DEFAULT_COLORING_ALGORITHM
 
 # # sparse with zygote and forward
 # dg = zeros(length(sp.rows))
@@ -209,23 +206,40 @@ sp = SparsePattern(ForwardAD(), tridiagonal!, ng, lx, ux)
 x = collect(range(0.2, 1.7, length=nx))
 Jdense = ForwardDiff.jacobian(tridiagonal!, zeros(ng), x)
 
-cache = SNOW.sparsejacobiancache(sp, ForwardAD(), tridiagonal!, nx, ng;
-    coloring_algorithm=BEST_OF_COLORING_ALGORITHM)
+dtype = ForwardAD(coloring_algorithm=BEST_OF_COLORING_ALGORITHM)
+@test dtype.coloring_algorithm === BEST_OF_COLORING_ALGORITHM
+cache = SNOW.sparsejacobiancache(sp, dtype, tridiagonal!, nx, ng)
 dg = zeros(length(sp.rows))
 SNOW.sparsejacobian!(dg, x, cache)
 Jsparse = Matrix(sparse(sp.rows, sp.cols, dg, ng, nx))
 @test isapprox(Jsparse, Jdense; atol=1e-8)
 
-cachefd = SNOW.sparsejacobiancache(sp, ForwardFD(), tridiagonal!, nx, ng;
-    coloring_algorithm=BEST_OF_COLORING_ALGORITHM)
+dtypefd = ForwardFD(coloring_algorithm=BEST_OF_COLORING_ALGORITHM)
+@test dtypefd.coloring_algorithm === BEST_OF_COLORING_ALGORITHM
+cachefd = SNOW.sparsejacobiancache(sp, dtypefd, tridiagonal!, nx, ng)
 dgfd = zeros(length(sp.rows))
 SNOW.sparsejacobian!(dgfd, x, cachefd)
 Jsparsefd = Matrix(sparse(sp.rows, sp.cols, dgfd, ng, nx))
 @test isapprox(Jsparsefd, Jdense; atol=1e-4)
 
-options = Options(sparsity=sp, derivatives=[ReverseAD(), ForwardAD()],
-    coloring_algorithm=BEST_OF_COLORING_ALGORITHM)
-@test options.coloring_algorithm === BEST_OF_COLORING_ALGORITHM
+# a user-supplied precomputed coloring (not a GreedyColoringAlgorithm) should
+# also work, exercising the fully generic ADTypes.AbstractColoringAlgorithm path
+Jsp = sparse(sp.rows, sp.cols, ones(length(sp.rows)), ng, nx)
+constalg = SparseMatrixColorings.ConstantColoringAlgorithm(Jsp, [mod1(i, 3) for i in 1:nx])
+
+dtypeconst = ForwardAD(coloring_algorithm=constalg)
+cacheconst = SNOW.sparsejacobiancache(sp, dtypeconst, tridiagonal!, nx, ng)
+dgconst = zeros(length(sp.rows))
+SNOW.sparsejacobian!(dgconst, x, cacheconst)
+Jsparseconst = Matrix(sparse(sp.rows, sp.cols, dgconst, ng, nx))
+@test isapprox(Jsparseconst, Jdense; atol=1e-8)
+
+dtypefdconst = ForwardFD(coloring_algorithm=constalg)
+cachefdconst = SNOW.sparsejacobiancache(sp, dtypefdconst, tridiagonal!, nx, ng)
+dgfdconst = zeros(length(sp.rows))
+SNOW.sparsejacobian!(dgfdconst, x, cachefdconst)
+Jsparsefdconst = Matrix(sparse(sp.rows, sp.cols, dgfdconst, ng, nx))
+@test isapprox(Jsparsefdconst, Jdense; atol=1e-4)
 
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,9 @@
 using SNOW
 using Test
 using Zygote
+using ForwardDiff
+using SparseArrays
+using SparseMatrixColorings
 
 snopttest = false
 
@@ -111,6 +114,232 @@ end
 #     # 9.865 μs (6 allocations: 11.63 KiB)
 # end
 # # ----------------------------------------
+
+
+@testset "sparse jacobian - finite differencing" begin
+
+# also exercises a trailing all-zero row/column: g[end] doesn't depend on
+# x at all, and x[end] doesn't affect any constraint - a regression check
+# for the sparsity-matrix dimensions being explicit (ng, nx).
+function dropped!(g, x)
+    n = length(x)
+    for i in 1:n-1
+        g[i] = x[i]^2 + sin(x[i])
+    end
+    g[n] = 1.0
+    return sum(abs2, x[1:n-1])
+end
+
+nx = 5
+ng = 5
+lx = -5*ones(nx)
+ux = 5*ones(nx)
+sp = SparsePattern(ForwardAD(), dropped!, ng, lx, ux)
+x = collect(range(0.2, 1.8, length=nx))
+Jdense = ForwardDiff.jacobian(dropped!, zeros(ng), x)
+
+cache = SNOW.sparsejacobiancache(sp, ForwardAD(), dropped!, nx, ng)
+dg = zeros(length(sp.rows))
+SNOW.sparsejacobian!(dg, x, cache)
+Jsparse = Matrix(sparse(sp.rows, sp.cols, dg, ng, nx))
+@test isapprox(Jsparse, Jdense; atol=1e-10)
+
+for dtype in (ForwardFD(), CentralFD(), ComplexStep())
+    cache = SNOW.sparsejacobiancache(sp, dtype, dropped!, nx, ng)
+    dgfd = zeros(length(sp.rows))
+    SNOW.sparsejacobian!(dgfd, x, cache)
+    Jsparsefd = Matrix(sparse(sp.rows, sp.cols, dgfd, ng, nx))
+    @test isapprox(Jsparsefd, Jdense; atol=1e-4)
+end
+
+end
+
+
+@testset "sparse jacobian - many colors" begin
+
+# g[1] depends on every x[i], so every column conflicts with every other
+# column in the coloring graph -> ncolors == nx. stresses the coloring path
+# well beyond the single/few-color cases covered above.
+function starfun!(g, x)
+    n = length(x)
+    g[1] = sum(x)
+    for i in 2:n
+        g[i] = x[i]^2 + 0.1*x[1]
+    end
+    return sum(abs2, x)
+end
+
+nx = 20
+ng = 20
+lx = -5*ones(nx)
+ux = 5*ones(nx)
+sp = SparsePattern(ForwardAD(), starfun!, ng, lx, ux)
+x = collect(range(0.1, 2.0, length=nx))
+Jdense = ForwardDiff.jacobian(starfun!, zeros(ng), x)
+
+cache = SNOW.sparsejacobiancache(sp, ForwardAD(), starfun!, nx, ng)
+dg = zeros(length(sp.rows))
+SNOW.sparsejacobian!(dg, x, cache)
+Jsparse = Matrix(sparse(sp.rows, sp.cols, dg, ng, nx))
+@test isapprox(Jsparse, Jdense; atol=1e-8)
+
+end
+
+
+@testset "sparse jacobian - named coloring algorithm presets" begin
+
+# default is the cheap natural-order coloring; users can opt into
+# BEST_OF_COLORING_ALGORITHM (or any other ADTypes.AbstractColoringAlgorithm)
+# for potentially fewer colors at a higher one-time cache-construction cost
+function tridiagonal!(g, x)
+    n = length(x)
+    g[1] = x[1]^2 - 2*x[2]
+    for i in 2:n-1
+        g[i] = x[i-1]*x[i] - x[i+1]^2 + sin(x[i])
+    end
+    g[n] = x[n]^2 - x[n-1]
+    return sum(abs2, x)
+end
+
+nx = 10
+ng = 10
+lx = -5*ones(nx)
+ux = 5*ones(nx)
+sp = SparsePattern(ForwardAD(), tridiagonal!, ng, lx, ux)
+x = collect(range(0.2, 1.7, length=nx))
+Jdense = ForwardDiff.jacobian(tridiagonal!, zeros(ng), x)
+
+cache = SNOW.sparsejacobiancache(sp, ForwardAD(), tridiagonal!, nx, ng;
+    coloring_algorithm=BEST_OF_COLORING_ALGORITHM)
+dg = zeros(length(sp.rows))
+SNOW.sparsejacobian!(dg, x, cache)
+Jsparse = Matrix(sparse(sp.rows, sp.cols, dg, ng, nx))
+@test isapprox(Jsparse, Jdense; atol=1e-8)
+
+cachefd = SNOW.sparsejacobiancache(sp, ForwardFD(), tridiagonal!, nx, ng;
+    coloring_algorithm=BEST_OF_COLORING_ALGORITHM)
+dgfd = zeros(length(sp.rows))
+SNOW.sparsejacobian!(dgfd, x, cachefd)
+Jsparsefd = Matrix(sparse(sp.rows, sp.cols, dgfd, ng, nx))
+@test isapprox(Jsparsefd, Jdense; atol=1e-4)
+
+options = Options(sparsity=sp, derivatives=[ReverseAD(), ForwardAD()],
+    coloring_algorithm=BEST_OF_COLORING_ALGORITHM)
+@test options.coloring_algorithm === BEST_OF_COLORING_ALGORITHM
+
+end
+
+
+@testset "sparse jacobian - non-square" begin
+
+# more constraints than variables (overdetermined), banded + wraparound
+# coupling so ng != nx and the sparsity matrix is rectangular
+function overdetermined!(g, x)
+    nx = length(x)
+    ng = length(g)
+    for i in 1:ng
+        j1 = ((i - 1) % nx) + 1
+        j2 = (i % nx) + 1
+        g[i] = 0.3*x[j1]^2 + (j2 != j1 ? 0.2*x[j2] : 0.0)
+    end
+    return sum(abs2, x)
+end
+
+nx = 6
+ng = 14
+lx = -5*ones(nx)
+ux = 5*ones(nx)
+x = collect(range(0.15, 1.9, length=nx))
+Jdense = ForwardDiff.jacobian(overdetermined!, zeros(ng), x)
+
+sp = SparsePattern(ForwardAD(), overdetermined!, ng, lx, ux)
+@test size(sparse(sp.rows, sp.cols, ones(length(sp.rows)), ng, nx)) == (ng, nx)
+
+cache = SNOW.sparsejacobiancache(sp, ForwardAD(), overdetermined!, nx, ng)
+dg = zeros(length(sp.rows))
+SNOW.sparsejacobian!(dg, x, cache)
+Jsparse = Matrix(sparse(sp.rows, sp.cols, dg, ng, nx))
+@test isapprox(Jsparse, Jdense; atol=1e-8)
+
+for dtype in (ForwardFD(), CentralFD(), ComplexStep())
+    cachefd = SNOW.sparsejacobiancache(sp, dtype, overdetermined!, nx, ng)
+    dgfd = zeros(length(sp.rows))
+    SNOW.sparsejacobian!(dgfd, x, cachefd)
+    Jsparsefd = Matrix(sparse(sp.rows, sp.cols, dgfd, ng, nx))
+    @test isapprox(Jsparsefd, Jdense; atol=1e-4)
+end
+
+end
+
+
+@testset "sparse jacobian - repeated evaluation" begin
+
+# a single cache must produce correct results across many calls at
+# different x, not just the first call (catches stale-state bugs in
+# reused scratch buffers / prepared coloring state)
+function tridiagonal!(g, x)
+    n = length(x)
+    g[1] = x[1]^2 - 2*x[2]
+    for i in 2:n-1
+        g[i] = x[i-1]*x[i] - x[i+1]^2 + sin(x[i])
+    end
+    g[n] = x[n]^2 - x[n-1]
+    return sum(abs2, x)
+end
+
+nx = 10
+ng = 10
+lx = -5*ones(nx)
+ux = 5*ones(nx)
+sp = SparsePattern(ForwardAD(), tridiagonal!, ng, lx, ux)
+
+cache = SNOW.sparsejacobiancache(sp, ForwardAD(), tridiagonal!, nx, ng)
+dg = zeros(length(sp.rows))
+
+for trial in 1:5
+    x = collect(range(0.1*trial, 0.1*trial + 1.5, length=nx))
+    SNOW.sparsejacobian!(dg, x, cache)
+    Jsparse = Matrix(sparse(sp.rows, sp.cols, dg, ng, nx))
+    Jdense = ForwardDiff.jacobian(tridiagonal!, zeros(ng), x)
+    @test isapprox(Jsparse, Jdense; atol=1e-8)
+end
+
+end
+
+
+@testset "sparse jacobian - empty sparsity" begin
+
+# constraints that don't depend on x at all: sp.rows/cols come back empty.
+# confirm the DifferentiationInterface path degrades gracefully rather
+# than erroring on a zero-color case.
+function constantfun!(g, x)
+    g[1] = 5.0
+    g[2] = -3.0
+    return sum(abs2, x)
+end
+
+nx = 4
+ng = 2
+lx = -5*ones(nx)
+ux = 5*ones(nx)
+sp = SparsePattern(ForwardAD(), constantfun!, ng, lx, ux)
+@test isempty(sp.rows)
+
+x = collect(range(0.3, 1.2, length=nx))
+
+cache = SNOW.sparsejacobiancache(sp, ForwardAD(), constantfun!, nx, ng)
+dg = zeros(length(sp.rows))
+SNOW.sparsejacobian!(dg, x, cache)
+@test isempty(dg)
+
+for dtype in (ForwardFD(), CentralFD(), ComplexStep())
+    cachefd = SNOW.sparsejacobiancache(sp, dtype, constantfun!, nx, ng)
+    dgfd = zeros(length(sp.rows))
+    SNOW.sparsejacobian!(dgfd, x, cachefd)
+    @test isempty(dgfd)
+end
+
+end
 
 
 @testset "optimization" begin


### PR DESCRIPTION
Follow-up to #25 (merged). Layers several improvements on top of the SparseDiffTools -> DifferentiationInterface + SparseMatrixColorings migration:

## Summary
- **Named coloring algorithm presets**: `DEFAULT_COLORING_ALGORITHM` (natural order, matches prior default) and `BEST_OF_COLORING_ALGORITHM` (tries natural, smallest-last, dynamic-largest-first, and incidence-degree orderings, keeps whichever gives fewest colors - never worse than the default, sometimes meaningfully better, e.g. ~20% fewer colors on some real-world sparsity patterns).
- **`coloring_algorithm` moved from `Options`/keyword to a field on the diff-method structs**: `ForwardAD(; coloring_algorithm=...)`, `ForwardFD(; coloring_algorithm=...)`, `CentralFD(; coloring_algorithm=...)`, `ComplexStep(; coloring_algorithm=...)`. This matches SNOW's existing precedent - `IPOPT(options=Dict())` and `SNOPT(...)` already hold their own config rather than `Options` reaching into it - and mirrors `DifferentiationInterface.AutoSparse`'s own shape (coloring algorithm as a field on the backend being configured). `Options` reverts to its original 3-field shape (`sparsity`, `derivatives`, `solver`).
- **Expanded test coverage**: non-square (overdetermined) Jacobians, empty sparsity patterns, repeated cache evaluation at different `x`, trailing all-zero row/column, many-colors worst case, named coloring presets and a user-supplied `ConstantColoringAlgorithm` exercised on **all** of `ForwardAD`/`ForwardFD`/`CentralFD`/`ComplexStep` (previously only AD/ForwardFD were exercised with a non-default coloring algorithm), and `UserDeriv` (dense + sparse) which previously had zero automated coverage. 72 assertions total, up from the ~30 on master today.
- **Expanded `guide.md` docs**: named presets, building custom `GreedyColoringAlgorithm` orderings (including a tuple-of-orderings best-of), and `ConstantColoringAlgorithm` for precomputed colorings.
- **Real-world benchmark**: `benchmark/sparse_jacobian_bench.jl` complements the existing `benchmark/benchmarks.jl` (synthetic tridiagonal-only) with worst-case coloring patterns, non-square Jacobians, and real SuiteSparse Matrix Collection matrices (`HB/orani678`, `FIDAP/ex11`) at much larger problem sizes.
- **Version bump to 1.0.0**: pre-1.0 versions cause caret-compat resolution to treat every minor bump as breaking (`^0.3.2` only allows `0.3.x`, not `0.4`), which has repeatedly caused downstream compat friction. This branch's additions plus the recent migration are a reasonable point to commit to a stable 1.x API.

## Benchmark
Real-world timing comparison (`sparse_jacobian_bench.jl`) against current `master`, same machine:

| problem | master setup | this PR setup | master eval | this PR eval |
|---|---|---|---|---|
| tridiagonal n2000 | 0.145ms | 0.179ms | 0.028ms | 0.028ms |
| laplacian2d n3600 | 0.414ms | 0.452ms | 0.066ms | 0.068ms |
| arrowhead n500 (worst-case colors) | 0.586ms | 0.652ms | 0.712ms | 0.714ms |
| arrowhead n2000 (worst-case colors) | 8.518ms | 8.769ms | 13.411ms | 13.472ms |
| non-square 2000x5000 | 0.236ms | 0.297ms | 0.019ms | 0.019ms |
| HB/orani678 (real economic model) | 20.871ms | 21.275ms | 37.716ms | 37.573ms |
| FIDAP/ex11 (real CFD matrix) | 88.757ms | 88.054ms | 41.264ms | 41.185ms |

All statistically tied (within normal run-to-run noise) - this PR's additions are purely additive (presets, tests, docs, API reshuffle) and introduce no performance regression relative to what's already merged.

## Test plan
- [x] Full test suite passes: 72 assertions across 8 testsets (derivatives, 5x sparse-jacobian edge cases, optimization)
- [x] `docs/src/guide.md` `@example` blocks execute cleanly end-to-end
- [x] Real-world benchmark run against current master, no regression (table above)

Supersedes #30 (closing that one - it predates #25 being merged and used a stale base).